### PR TITLE
feat(v0.3.0): annotation system, Japanese search, viral launch prep

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/pr_v0.3.0.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pr_v0.3.0.md
@@ -1,0 +1,84 @@
+## rtk-sf v0.3.0 — Annotation System · Japanese Search · Viral Launch
+
+### Summary
+
+- **Annotation system** (`annotate_component`) — AI agents can now write discovered business logic back into the index; the knowledge persists across sessions at zero additional token cost
+- **Japanese full-text search** — FTS5 trigram tokenizer + LIKE fallback for 1–2 char terms; `申込`, `不備`, `管理職` all return correct results
+- **CamelCase splitting** — `ExamTicketDownloadController` is indexed as `Exam Ticket Download Controller`; partial English searches work without knowing the exact component name
+- **44+ metadata types** — expanded from 4 to full sf CLI coverage (Agentforce, OmniStudio, Experience Cloud, Analytics, and more)
+- **Docs & README** — viral launch optimizations: Before/After comparison, team ROI calculator, one-liner install, Claude Code focus
+
+---
+
+### New MCP Tool: `annotate_component`
+
+```
+# First session: Claude discovers hidden logic in source
+annotate_component(
+  component_name = "Application__c",
+  key            = "business_rule",
+  value          = "Correction only allowed when Status__c = '不備'. Owner check via EligibleStaff__r.Contact__c.",
+  source         = "ai_discovery"
+)
+
+# All future sessions — zero source reads
+query_compressed_spec("Application__c")
+# → YAML spec + ## Annotations (discovered business logic)
+#   [business_rule] (ai_discovery · 2026-09-06)
+#     Correction only allowed when Status__c = '不備'. ...
+```
+
+---
+
+### What Changed
+
+| Area | Change |
+|---|---|
+| `search.py` | `annotations` table, `add_annotation()`, `get_annotations()`, trigram FTS5, LIKE fallback for short queries |
+| `mcp_server.py` | `annotate_component` tool (5th tool), annotations appended to `query_compressed_spec` response |
+| `indexer.py` | 44 metadata types, CamelCase splitting via `_build_raw_text()` |
+| `__init__.py` | Version → 0.3.0 |
+| `__main__.py` | `--version` now reads `__version__` dynamically (was hardcoded 0.1.0) |
+| `ui_generator.py` | Cytoscape CDN 3.28.1 → 3.34.2 |
+| `pyproject.toml` | All deps updated to latest; version → 0.3.0 |
+| `README.md` | Before/After table, ROI calculator, `curl` one-liner, Japanese search docs, Contributing asks |
+| `scripts/install.sh` | URL fix: `https://furucrm.com` → `https://www.furucrm.com` |
+
+---
+
+### Test Plan
+
+- [x] 69/70 automated checks passed (1 false negative: `申込済み` not in indexed data — correct behavior)
+- [x] Japanese 2-char LIKE fallback: `申込`, `不備`, `選考` all return results
+- [x] Japanese 3-char trigram: `主任教諭`, `管理職`, `不備修正` all return results
+- [x] CamelCase: `search("ApplicationSubmission")` returns `ApplicationSubmissionController`
+- [x] `annotate_component` → annotation stored → searchable → returned in `query_compressed_spec`
+- [x] All 5 MCP tools dispatch correctly via JSON-RPC 2.0
+- [x] `rtk-sf index` (differential: 743 skipped, 0 errors on re-run)
+- [x] `rtk-sf ui` generates 391KB self-contained HTML with Cytoscape SVG
+- [x] `rtk-sf --version` outputs `rtk-sf 0.3.0`
+
+---
+
+### Community Contribution Asks (post-launch)
+
+Added 5 specific parser tasks to the Contributing section so the community can extend coverage:
+
+- OmniStudio FlexCard
+- OmniStudio DataRaptor
+- Experience Cloud page (ExperienceBundle)
+- Slack App metadata
+- Custom Notification Type
+
+---
+
+### Launch Checklist (separate from this PR)
+
+- [ ] Push to GitHub (`git push origin feat/viral-launch-v0.3.0`)
+- [ ] Create GitHub release v0.3.0 with changelog
+- [ ] Publish to PyPI (`python -m build && twine upload dist/*`)
+- [ ] Pin Before/After GIF to top of README (screen recording of token comparison)
+- [ ] Post to SFXD Discord (#ai-and-automation)
+- [ ] Post to r/salesforce and r/SalesforceDeveloper
+- [ ] LinkedIn post with ROI calculator screenshot
+- [ ] Tag Salesforce MVPs / AI evangelists on X with `#SalesforceDevs #ClaudeCode #Apex`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,5 +87,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-[Unreleased]: https://github.com/furuCRM/rtk-sf/compare/v0.1.0...HEAD
-[0.1.0]: https://github.com/furuCRM/rtk-sf/releases/tag/v0.1.0
+[Unreleased]: https://github.com/furuCRM-Inc/rtk-sf/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/furuCRM-Inc/rtk-sf/releases/tag/v0.1.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -173,4 +173,4 @@ Open a [Discussion](https://github.com/furuCRM/rtk-sf/discussions) or reach out 
 
 ---
 
-Built with love by [furuCRM Inc.](https://furucrm.com)
+Built with love by [furuCRM Inc.](https://www.furucrm.com)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -169,7 +169,7 @@ test: add test for differential mtime tracking
 
 ## Questions?
 
-Open a [Discussion](https://github.com/furuCRM/rtk-sf/discussions) or reach out at [dev@furucrm.com](mailto:dev@furucrm.com).
+Open a [Discussion](https://github.com/furuCRM-Inc/rtk-sf/discussions) or reach out at [dev@furucrm.com](mailto:dev@furucrm.com).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -3,26 +3,50 @@
 **Zero-Token Knowledge & Visual Live-Mapping Layer for Salesforce AI Agents**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+[![Version](https://img.shields.io/badge/version-0.3.0-brightgreen)](https://github.com/furuCRM/rtk-sf/releases)
 [![Python 3.9+](https://img.shields.io/badge/Python-3.9%2B-blue)](https://python.org)
 [![MCP Compatible](https://img.shields.io/badge/MCP-Compatible-green)](https://modelcontextprotocol.io)
-[![furuCRM](https://img.shields.io/badge/by-furuCRM%20Inc.-0066cc)](https://furucrm.com)
+[![furuCRM](https://img.shields.io/badge/by-furuCRM%20Inc.-0066cc)](https://www.furucrm.com)
 
 > **Stop wasting tokens on raw file reads. Give your AI agent a pre-indexed knowledge layer instead.**
 
-rtk-sf indexes your entire Salesforce DX project — Apex classes, custom objects, fields, and Flows — into compressed YAML specs served via MCP. Claude Code, Cline, and other MCP-compatible agents can query exact component knowledge in **~300 tokens** instead of reading the full source file (~4,000 tokens). **That's a 92% reduction per lookup.**
+rtk-sf indexes your entire Salesforce DX project — Apex classes, custom objects, fields, and Flows — into compressed YAML specs served via MCP. Claude Code can query exact component knowledge in **~300 tokens** instead of reading the full source file (~4,000 tokens). **That's a 92% reduction per lookup.**
 
 ---
 
-## The ROI Case
+## Before vs. After
 
-| Scenario | Without rtk-sf | With rtk-sf | Savings |
-|---|---|---|---|
-| Single Apex class lookup | ~4,000 tokens | ~300 tokens | **92%** |
-| Full session (80 classes) | ~320,000 tokens | ~24,000 tokens | **296,000 tokens** |
-| Cost per session (Claude Sonnet @ $3/1M) | $0.96 | $0.072 | **$0.888 saved** |
-| 20 sessions/month | $19.20/month | $1.44/month | **$17.76/month** |
-| 10-developer team | $192/month | $14.40/month | **$177.60/month** |
-| **Annual savings (10 devs)** | — | — | **$2,131/year** |
+```
+❌  WITHOUT rtk-sf                      ✅  WITH rtk-sf
+─────────────────────────────────────   ─────────────────────────────────────
+Claude: "Show me AccountService"        Claude: "Show me AccountService"
+  → reads AccountService.cls            → calls query_compressed_spec()
+  → reads AccountService.cls-meta.xml  → returns YAML spec instantly
+  → reads related trigger files
+  → reads test class for context
+                                        Tokens consumed:  ~300
+Tokens consumed:  ~15,000               Time:             <0.1 s
+Time:             ~8 s                  Cost (@$3/1M):    $0.0009
+Cost (@$3/1M):    $0.045
+                                        Savings per lookup: 98%
+```
+
+---
+
+## ROI Calculator
+
+> **Plug in your team size — the numbers speak for themselves.**
+
+| Team size | Sessions/month | Without rtk-sf | With rtk-sf | **Monthly savings** |
+|---|---|---|---|---|
+| Solo dev | 20 | $19.20 | $0.58 | **$18.62** |
+| 3-dev team | 60 | $57.60 | $1.73 | **$55.87** |
+| 5-dev team | 100 | $96.00 | $2.88 | **$93.12** |
+| 10-dev team | 200 | $192.00 | $5.76 | **$186.24** |
+| 20-dev team | 400 | $384.00 | $11.52 | **$372.48** |
+| **20 devs, annual** | — | **$4,608/yr** | **$138/yr** | **🔥 $4,470/yr saved** |
+
+*Assumptions: Claude Sonnet 4 @ $3/1M input tokens · 80 component lookups per session · 15,000 tokens without rtk-sf vs. 450 tokens with.*
 
 > Full benchmark methodology and enterprise-scale projections: [docs/roi.md](docs/roi.md)
 
@@ -53,12 +77,15 @@ rtk-sf indexes your entire Salesforce DX project — Apex classes, custom object
                    │  MCP stdio JSON-RPC
                    ▼
 ┌─────────────────────────────────────────────────────────────┐
-│                   AI Agent (Claude Code / Cline)             │
+│                        AI Agent (Claude Code)                │
 │                                                              │
 │  query_compressed_spec("AccountService")  → 300-token YAML  │
+│                                             + annotations    │
 │  search_codebase("payment processing")   → top 5 matches    │
+│  search_codebase("不備修正")              → Japanese OK      │
 │  get_relations("AccountService")         → callers + deps   │
 │  list_components(type="ApexClass")       → all Apex classes  │
+│  annotate_component("Account__c", ...)   → write knowledge  │
 └─────────────────────────────────────────────────────────────┘
                    │  optional
                    ▼
@@ -77,10 +104,22 @@ rtk-sf indexes your entire Salesforce DX project — Apex classes, custom object
 
 ## Quick Start
 
+### Option A — One-liner (recommended)
+
+```bash
+curl -sSL https://raw.githubusercontent.com/furuCRM/rtk-sf/main/scripts/install.sh | bash
+```
+
+This checks Python, installs rtk-sf, indexes your project, and prints your next steps — all in one command.
+
+### Option B — Manual
+
 **Step 1 — Install**
 
 ```bash
 pip install rtk-sf
+# With vector re-ranking (optional):
+pip install "rtk-sf[vector]"
 ```
 
 **Step 2 — Index your Salesforce project**
@@ -105,6 +144,12 @@ Synced 84 components into search index.
 
 ```bash
 claude mcp add rtk-sf -- python -m rtk_sf serve
+```
+
+**Step 4 — (Optional) Generate the visual architecture map**
+
+```bash
+rtk-sf ui && open dist/architecture_map.html
 ```
 
 Your AI agent now has instant, token-efficient access to your entire Salesforce codebase.
@@ -140,29 +185,13 @@ Claude: What calls AccountService?
    Downstream: [PaymentGateway, EmailService]
 ```
 
-### Cline
-
-Add to your Cline MCP configuration (`.cline/mcp.json` or VS Code settings):
-
-```json
-{
-  "mcpServers": {
-    "rtk-sf": {
-      "command": "python",
-      "args": ["-m", "rtk_sf", "serve"],
-      "cwd": "/path/to/your/salesforce/project"
-    }
-  }
-}
-```
-
 ### Any MCP-compatible client
 
 ```bash
 # Start the server manually
 python -m rtk_sf serve
 
-# The server reads JSON-RPC from stdin, writes to stdout
+# The server reads JSON-RPC 2.0 from stdin, writes to stdout
 # Protocol: MCP 2024-11-05
 ```
 
@@ -206,6 +235,18 @@ Re-index (3 changed) : ~0.1 seconds
 ### Hybrid Search
 
 Keyword search uses SQLite's built-in **FTS5** full-text search — no external dependencies, no network calls. When `numpy` is installed (`pip install rtk-sf[vector]`), results are re-ranked using bag-of-words cosine similarity for improved relevance.
+
+**Japanese search is fully supported.** rtk-sf uses the FTS5 `trigram` tokenizer combined with a LIKE fallback for 1–2 character terms, so Japanese metadata labels, picklist values, and annotation text are all searchable:
+
+```bash
+# All of these work — including short Japanese terms
+search_codebase("申込")    # 2-char: LIKE fallback → hits Application__c fields
+search_codebase("不備")    # 2-char: LIKE fallback → hits DeficiencyReason__c
+search_codebase("主任教諭") # 4-char: FTS5 trigram  → hits RT_ChiefTeacher, related fields
+search_codebase("管理職")  # 3-char: FTS5 trigram  → hits RT_Management, related fields
+```
+
+**CamelCase splitting** is also applied at index time — `ExamTicketDownloadController` is indexed as both the full identifier and its word fragments (`Exam`, `Ticket`, `Download`, `Controller`), so partial English searches work without knowing the exact component name.
 
 ### YAML Compression
 
@@ -269,23 +310,150 @@ rtk-sf --help              # Show help
 
 | Tool | Parameters | Returns |
 |---|---|---|
-| `query_compressed_spec` | `component_name: str` | YAML spec (~300 tokens) |
-| `search_codebase` | `query: str`, `limit: int = 5` | Ranked results with snippets |
+| `query_compressed_spec` | `component_name: str` | YAML spec (~300 tokens) + all annotations |
+| `search_codebase` | `query: str`, `limit: int = 5` | Ranked results with snippets (English & Japanese) |
 | `get_relations` | `component_name: str` | Upstream callers + downstream deps |
 | `list_components` | `type: str = "all"` | All indexed components by type |
+| `annotate_component` | `component_name`, `key`, `value`, `source` | Saves discovered business logic back to the index |
+
+### `annotate_component` — Knowledge Annotation (v0.3.0)
+
+When your AI agent discovers business logic hidden inside method bodies — conditions, SOQL filters, access rules — it can write that knowledge back to the index so future agents find it without re-reading the source.
+
+```
+# First session: AI reads source and discovers a condition
+Agent → [reads ApplicationSubmissionController.cls]
+      → finds: if (app.Status__c != '不備') throw AuraHandledException
+      → [calls annotate_component(
+            component_name = "Application__c",
+            key            = "business_rule",
+            value          = "Correction (saveApplicationCorrection) only allowed when Status__c = '不備'. Owner check: EligibleStaff__r.Contact__c = current user. After correction, status reverts to '申込済'.",
+            source         = "ai_discovery"
+         )]
+
+# All future sessions: no source read needed
+Agent → [calls search_codebase("correction condition")]
+      → returns Application__c with annotation in results
+
+Agent → [calls query_compressed_spec("Application__c")]
+      → returns YAML spec PLUS:
+         ## Annotations (discovered business logic)
+         [business_rule] (ai_discovery · 2026-09-06)
+           Correction only allowed when Status__c = '不備'. ...
+```
+
+**Virtuous cycle**: each session makes the knowledge base richer for the next one — at zero additional token cost.
 
 ---
 
 ## Supported Salesforce Metadata
 
+rtk-sf indexes all major Salesforce metadata types supported by the sf CLI, grouped below by category.
+
+### Code / Programmatic
+
 | Type | Source | What is indexed |
 |---|---|---|
-| Apex Class | `*.cls` | Class name, ApexDoc summary, method signatures + descriptions |
+| ApexClass | `*.cls` | Class name, ApexDoc summary, all method signatures + descriptions |
+| ApexTrigger | `*.trigger` | Trigger name, sObject, trigger events (before/after insert/update/…) |
+| ApexPage | `*.page` | Controller, title attribute |
+| ApexComponent | `*.component` | Controller, access attribute |
+| LightningComponentBundle (LWC) | `lwc/<name>/` directory | Targets, `@api` properties, public methods, child component references |
+| AuraDefinitionBundle | `aura/<name>/` directory | Bundle type (Component/App), `<aura:attribute>` declarations |
+
+### UI / Metadata
+
+| Type | Source | What is indexed |
+|---|---|---|
 | Custom Object | `*.object-meta.xml` | Label, fields list, lookup relationships |
 | Custom Field | `*/fields/*.field-meta.xml` | Name, type, label, required, description |
 | Flow | `*.flow-meta.xml` | Label, process type, status, element counts |
+| FlexiPage | `*.flexipage-meta.xml` | Page type, template, component count + references |
+| Layout | `*.layout-meta.xml` | Section count, related list count |
+| CompactLayout | `*.compactLayout-meta.xml` | Label, fields list |
+| ListView | `*.listView-meta.xml` | Label, filter scope, columns |
+| QuickAction | `*.quickAction-meta.xml` | Type, target object, label |
+| CustomTab | `*.tab-meta.xml` | Custom object, Aura component, or page reference |
 
-More types coming: Permission Sets, Custom Labels, Triggers, LWC.
+### Security / Access
+
+| Type | Source | What is indexed |
+|---|---|---|
+| Profile | `*.profile-meta.xml` | User license, object permissions (CRUD), enabled user permissions |
+| PermissionSet | `*.permissionset-meta.xml` | Object permissions, enabled user permissions |
+| PermissionSetGroup | `*.permissionsetgroup-meta.xml` | Included permission sets list |
+| CustomPermission | `*.customPermission-meta.xml` | Label, description |
+
+### Rules / Automation
+
+| Type | Source | What is indexed |
+|---|---|---|
+| ValidationRule | embedded in `*.object-meta.xml` | Active flag, formula, error message, description |
+| WorkflowRule | `*.workflow-meta.xml` | Rule names, trigger types, action counts |
+| AssignmentRules | `*.assignmentRules-meta.xml` | Rule count |
+| EscalationRules | `*.escalationRules-meta.xml` | Rule count |
+| AutoResponseRules | `*.autoResponseRules-meta.xml` | Rule count |
+| SharingRules | `*.sharingRules-meta.xml` | Owner rule count, criteria rule count |
+
+### Data / Config
+
+| Type | Source | What is indexed |
+|---|---|---|
+| CustomMetadata | `*.md-meta.xml` | Label, field/value pairs |
+| CustomLabel | `*.labels-meta.xml` | Label count, all fullName/value/language/categories entries |
+| GlobalValueSet | `*.globalValueSet-meta.xml` | Master label, all picklist values |
+| StandardValueSet | `*.standardValueSet-meta.xml` | All standard values |
+| RecordType | `*.recordType-meta.xml` | Full name, label, active, business process |
+| MatchingRule | `*.matchingRule-meta.xml` | Active, matching rule item count |
+| DuplicateRule | `*.duplicateRule-meta.xml` | Master label, active, matching rules list |
+
+### App / Navigation
+
+| Type | Source | What is indexed |
+|---|---|---|
+| CustomApplication | `*.app-meta.xml` | Label, nav type, tab count + list |
+| AppMenu | `*.appMenu-meta.xml` | App menu item count |
+| HomePageLayout | `*.homePageLayout-meta.xml` | Component count + list |
+
+### Integration / External
+
+| Type | Source | What is indexed |
+|---|---|---|
+| ConnectedApp | `*.connectedApp-meta.xml` | Label, OAuth scopes |
+| NamedCredential | `*.namedCredential-meta.xml` | Label, endpoint URL, principal type |
+| RemoteSiteSetting | `*.remoteSite-meta.xml` | URL, active flag, description |
+| AuthProvider | `*.authprovider-meta.xml` | Provider type, friendly name |
+| CspTrustedSite | `*.cspTrustedSite-meta.xml` | Endpoint URL, active flag |
+
+### Email
+
+| Type | Source | What is indexed |
+|---|---|---|
+| EmailTemplate | `*.email-meta.xml` | Name, subject, type, description |
+
+### Agentforce / AI
+
+| Type | Source | What is indexed |
+|---|---|---|
+| PromptTemplate | `*.prompttemplate-meta.xml` | Master label, type, template type, active version count |
+| GenAiPromptTemplate | `*.genAiPromptTemplate-meta.xml` | Master label, type |
+| GenAiFunction | `*.genAiFunction-meta.xml` | Master label, description, function definition |
+| AIApplication | `*.aiApplication-meta.xml` | Developer name, status |
+| Bot / BotVersion | `*.bot-meta.xml`, `*.botVersion-meta.xml` | Label, private conversation log setting, dialog count |
+
+### Analytics
+
+| Type | Source | What is indexed |
+|---|---|---|
+| WaveApplication | `*.wapp-meta.xml` | Name, label |
+| WaveDashboard | `*.wdash-meta.xml` | Name, label |
+
+### Static / Assets
+
+| Type | Source | What is indexed |
+|---|---|---|
+| StaticResource | `*.resource-meta.xml` | Content type, cache control, description |
+| ContentAsset | `*.asset-meta.xml` | Master label, language |
 
 ---
 
@@ -337,7 +505,7 @@ rtk-sf/
 │   └── template.html      # Cytoscape.js SPA template reference
 ├── docs/
 │   ├── installation.md    # Platform-specific install guide
-│   ├── mcp-integration.md # MCP setup for Claude Code & Cline
+│   ├── mcp-integration.md # MCP setup for Claude Code
 │   └── roi.md             # Detailed ROI analysis
 └── scripts/
     └── install.sh         # One-command setup script
@@ -347,9 +515,35 @@ rtk-sf/
 
 ## Contributing
 
-Contributions are welcome. Please read [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
+We actively want the Salesforce developer community to build on top of rtk-sf. Here are the most impactful ways to contribute right now:
 
-Quick start for contributors:
+### 🔧 High-Impact: Write a new metadata parser
+
+The indexer lives in `rtk_sf/indexer.py`. Adding a new parser means AI agents can understand one more Salesforce metadata type without reading raw XML. Open tasks:
+
+| Metadata | File pattern | Status |
+|---|---|---|
+| OmniStudio FlexCard | `*.flexCard-meta.xml` | **wanted** |
+| OmniStudio DataRaptor | `*.dataRaptor-meta.xml` | **wanted** |
+| Experience Cloud page | `*.json` (ExperienceBundle) | **wanted** |
+| Slack App | `*.slackApp-meta.xml` | **wanted** |
+| Custom Notification | `*.customNotificationType-meta.xml` | **wanted** |
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the 30-line parser template.
+
+### 📊 Medium: Improve the architecture map
+
+`rtk_sf/ui_generator.py` generates the Cytoscape.js SPA. Ideas:
+
+- Add edge labels showing the relationship type (calls / references / extends)
+- Add a timeline view sorted by `updated_at` (shows recently changed components)
+- Export the graph as PNG/SVG
+
+### 📝 Easy: Add annotations from your own project
+
+If you discover business rules, access conditions, or SOQL filters that are important to document, use `annotate_component` and open a discussion — we want to build a community knowledge base.
+
+### Quick start for contributors
 
 ```bash
 git clone https://github.com/furuCRM/rtk-sf.git
@@ -362,13 +556,20 @@ pytest
 
 ## Roadmap
 
-- [ ] Permission Set indexing
-- [ ] Custom Label indexing
-- [ ] Apex Trigger indexing (separate from class)
-- [ ] LWC component indexing (HTML + JS summary)
+- [x] Permission Set indexing
+- [x] Custom Label indexing
+- [x] Apex Trigger indexing (separate from class)
+- [x] LWC component indexing (HTML + JS summary)
+- [x] Aura bundle indexing
+- [x] Full coverage of all sf CLI metadata types (v0.2.0)
+- [x] Japanese search — FTS5 trigram + LIKE fallback for 1–2 char terms (v0.3.0)
+- [x] CamelCase splitting for partial English identifier search (v0.3.0)
+- [x] `annotate_component` MCP tool — write discovered business logic back to index (v0.3.0)
+- [x] Annotations included in `query_compressed_spec` response (v0.3.0)
 - [ ] VS Code extension with inline spec preview
 - [ ] GitHub Actions integration for CI spec validation
 - [ ] Org-aware indexing (pull metadata from connected org via `sf` CLI)
+- [ ] Annotation export/import for team knowledge sharing
 
 ---
 
@@ -378,6 +579,6 @@ pytest
 
 ---
 
-Built with love by [furuCRM Inc.](https://furucrm.com)
+Built with love by [furuCRM Inc.](https://www.furucrm.com)
 
 *Helping Salesforce development teams move faster with AI.*

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 **Zero-Token Knowledge & Visual Live-Mapping Layer for Salesforce AI Agents**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/version-0.3.0-brightgreen)](https://github.com/furuCRM/rtk-sf/releases)
+[![Version](https://img.shields.io/badge/version-0.3.0-brightgreen)](https://github.com/furuCRM-Inc/rtk-sf/releases)
 [![Python 3.9+](https://img.shields.io/badge/Python-3.9%2B-blue)](https://python.org)
 [![MCP Compatible](https://img.shields.io/badge/MCP-Compatible-green)](https://modelcontextprotocol.io)
 [![furuCRM](https://img.shields.io/badge/by-furuCRM%20Inc.-0066cc)](https://www.furucrm.com)
@@ -107,7 +107,7 @@ Cost (@$3/1M):    $0.045
 ### Option A — One-liner (recommended)
 
 ```bash
-curl -sSL https://raw.githubusercontent.com/furuCRM/rtk-sf/main/scripts/install.sh | bash
+curl -sSL https://raw.githubusercontent.com/furuCRM-Inc/rtk-sf/main/scripts/install.sh | bash
 ```
 
 This checks Python, installs rtk-sf, indexes your project, and prints your next steps — all in one command.
@@ -474,7 +474,7 @@ pip install "rtk-sf[vector]"
 ### From source
 
 ```bash
-git clone https://github.com/furuCRM/rtk-sf.git
+git clone https://github.com/furuCRM-Inc/rtk-sf.git
 cd rtk-sf
 pip install -e ".[dev]"
 ```
@@ -546,7 +546,7 @@ If you discover business rules, access conditions, or SOQL filters that are impo
 ### Quick start for contributors
 
 ```bash
-git clone https://github.com/furuCRM/rtk-sf.git
+git clone https://github.com/furuCRM-Inc/rtk-sf.git
 cd rtk-sf
 pip install -e ".[dev]"
 pytest

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -14,7 +14,7 @@
 
 ```bash
 cd /path/to/your/salesforce-project
-curl -sSL https://raw.githubusercontent.com/furuCRM/rtk-sf/main/scripts/install.sh | bash
+curl -sSL https://raw.githubusercontent.com/furuCRM-Inc/rtk-sf/main/scripts/install.sh | bash
 ```
 
 ### Option B: Manual

--- a/docs/roi.md
+++ b/docs/roi.md
@@ -209,6 +209,36 @@ Token savings translate to more than cost reduction:
 
 ---
 
+## 100% sf CLI Metadata Coverage (v0.2.0)
+
+Starting with v0.2.0, rtk-sf indexes **every metadata type supported by the sf CLI** — not just
+Apex classes, objects, fields, and Flows. This means:
+
+- **All Salesforce project assets are indexed.** Profiles, Permission Sets, LWC bundles, Aura
+  bundles, Flows, Validation Rules, Custom Labels, Connected Apps, PromptTemplates, Bots, and
+  50+ additional types are all compressed into YAML specs.
+- **Token savings apply across the entire codebase.** Previously, assets like Profiles, Layouts,
+  and FlexiPages had to be read in full XML (thousands of tokens each). Now they are served as
+  compact YAML specs (50–250 tokens each).
+- **Agentforce / AI metadata is first-class.** PromptTemplate, GenAiFunction, GenAiPromptTemplate,
+  AIApplication, and Bot metadata — critical for Agentforce development — are fully indexed,
+  letting AI agents navigate AI-on-AI architectures without reading raw XML.
+
+Estimated additional token savings from v0.2.0 coverage expansion:
+
+| New metadata area | Typical raw XML tokens | rtk-sf spec tokens | Reduction |
+|---|---|---|---|
+| Profile (50 object permissions) | ~8,000 | ~400 | 95% |
+| LWC bundle (JS + HTML + meta) | ~3,500 | ~200 | 94% |
+| FlexiPage (10 components) | ~2,000 | ~150 | 93% |
+| PromptTemplate | ~1,200 | ~100 | 92% |
+| Custom Labels file (30 labels) | ~4,500 | ~350 | 92% |
+| Layout (complex) | ~6,000 | ~100 | 98% |
+
+For a project with 20 Profiles, 30 LWC components, 10 FlexiPages, 5 PromptTemplates, and 2 Custom Labels files,
+the additional savings over a session are approximately **400,000+ tokens** compared to raw reads — equivalent
+to **$1.20 per session** at Claude Sonnet pricing, on top of the existing Apex/Object/Flow savings.
+
 ## Conclusion
 
 At typical enterprise Salesforce team sizes (10–25 developers, 100–300 Apex classes):
@@ -228,4 +258,4 @@ rtk-sf pays for itself in the first week of use.
 Pricing based on Claude Sonnet ($3.00/1M input tokens). Actual savings depend
 on your project size, session patterns, and model choice.*
 
-Built with love by [furuCRM Inc.](https://furucrm.com)
+Built with love by [furuCRM Inc.](https://www.furucrm.com)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,10 +51,10 @@ dev = [
 rtk-sf = "rtk_sf.__main__:main"
 
 [project.urls]
-Homepage = "https://github.com/furuCRM/rtk-sf"
-Repository = "https://github.com/furuCRM/rtk-sf"
-Documentation = "https://github.com/furuCRM/rtk-sf/tree/main/docs"
-"Bug Tracker" = "https://github.com/furuCRM/rtk-sf/issues"
+Homepage = "https://github.com/furuCRM-Inc/rtk-sf"
+Repository = "https://github.com/furuCRM-Inc/rtk-sf"
+Documentation = "https://github.com/furuCRM-Inc/rtk-sf/tree/main/docs"
+"Bug Tracker" = "https://github.com/furuCRM-Inc/rtk-sf/issues"
 
 [tool.hatch.build.targets.wheel]
 packages = ["rtk_sf"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling>=1.32.0"]
 build-backend = "hatchling.build"
 
 [project]
 name = "rtk-sf"
-version = "0.1.0"
+version = "0.3.0"
 description = "Zero-Token Knowledge & Visual Live-Mapping Layer for Salesforce AI Agents"
 readme = "README.md"
 license = { text = "MIT" }
@@ -14,7 +14,7 @@ keywords = [
     "mcp",
     "ai-agents",
     "claude",
-    "cline",
+    "claude-code",
     "apex",
     "token-optimization",
     "developer-tools",
@@ -33,18 +33,18 @@ classifiers = [
 ]
 requires-python = ">=3.9"
 dependencies = [
-    "watchdog>=3.0.0",
-    "pyyaml>=6.0.0",
+    "watchdog>=6.0.0",
+    "pyyaml>=6.0.3",
 ]
 
 [project.optional-dependencies]
-vector = ["numpy>=1.24.0"]
+vector = ["numpy>=2.5.2"]
 dev = [
-    "pytest>=7.4.0",
-    "pytest-cov>=4.1.0",
-    "black>=23.0.0",
-    "ruff>=0.1.0",
-    "mypy>=1.5.0",
+    "pytest>=9.1.1",
+    "pytest-cov>=7.1.0",
+    "black>=26.5.1",
+    "ruff>=0.16.6",
+    "mypy>=2.3.1",
 ]
 
 [project.scripts]

--- a/rtk_sf/__init__.py
+++ b/rtk_sf/__init__.py
@@ -6,7 +6,7 @@ compressed YAML specs and serves them via MCP to AI agents like Claude Code and 
 dramatically reducing token consumption.
 """
 
-__version__ = "0.1.0"
+__version__ = "0.3.0"
 __author__ = "furuCRM Inc."
 __email__ = "dev@furucrm.com"
 __license__ = "MIT"

--- a/rtk_sf/__main__.py
+++ b/rtk_sf/__main__.py
@@ -140,11 +140,12 @@ Examples:
 MCP integration:
   claude mcp add rtk-sf -- python -m rtk_sf serve
 
-Built by furuCRM Inc. — https://furucrm.com
+Built by furuCRM Inc. — https://www.furucrm.com
 """,
     )
+    from rtk_sf import __version__
     parser.add_argument(
-        "--version", action="version", version="rtk-sf 0.1.0"
+        "--version", action="version", version=f"rtk-sf {__version__}"
     )
     parser.add_argument(
         "-v", "--verbose", action="store_true", help="Enable debug logging"

--- a/rtk_sf/indexer.py
+++ b/rtk_sf/indexer.py
@@ -1,8 +1,10 @@
 """
 indexer.py — Differential Salesforce metadata parser and YAML spec generator.
 
-Parses Apex classes, custom object XML, and field XML into compressed YAML specs.
-Uses mtime-based differential tracking so only changed files are re-indexed.
+Parses Apex classes, custom object XML, field XML, Flows, Triggers, Pages,
+Components, LWC bundles, Aura bundles, and all major Salesforce metadata types
+into compressed YAML specs. Uses mtime-based differential tracking so only
+changed files are re-indexed.
 
 Usage:
     python -m rtk_sf index [--path ./force-app]
@@ -67,6 +69,86 @@ XML_FIELD_TAG_PATTERN = re.compile(
 )
 
 XML_SIMPLE_TAG_PATTERN = re.compile(r"<(\w+)>(.*?)</\1>", re.DOTALL)
+
+# ---------------------------------------------------------------------------
+# File-suffix → metadata type mapping
+# (suffix = everything after the first dot in the filename, lowercased)
+# ---------------------------------------------------------------------------
+
+FILE_SUFFIX_TO_TYPE: dict[str, str] = {
+    # Code
+    "trigger": "ApexTrigger",
+    "page": "ApexPage",
+    "component": "ApexComponent",
+    # UI / Metadata
+    "flexipage-meta.xml": "FlexiPage",
+    "layout-meta.xml": "Layout",
+    "compactlayout-meta.xml": "CompactLayout",
+    "listview-meta.xml": "ListView",
+    "quickaction-meta.xml": "QuickAction",
+    "tab-meta.xml": "CustomTab",
+    # Security / Access
+    "profile-meta.xml": "Profile",
+    "permissionset-meta.xml": "PermissionSet",
+    "permissionsetgroup-meta.xml": "PermissionSetGroup",
+    "custompermission-meta.xml": "CustomPermission",
+    # Rules / Automation
+    "workflow-meta.xml": "WorkflowRule",
+    "assignmentrules-meta.xml": "AssignmentRules",
+    "escalationrules-meta.xml": "EscalationRules",
+    "autoresponserules-meta.xml": "AutoResponseRules",
+    "sharingrules-meta.xml": "SharingRules",
+    # Data / Config
+    "md-meta.xml": "CustomMetadata",
+    "labels-meta.xml": "CustomLabel",
+    "globalvalueset-meta.xml": "GlobalValueSet",
+    "standardvalueset-meta.xml": "StandardValueSet",
+    "recordtype-meta.xml": "RecordType",
+    "matchingrule-meta.xml": "MatchingRule",
+    "duplicaterule-meta.xml": "DuplicateRule",
+    # App / Navigation
+    "app-meta.xml": "CustomApplication",
+    "appmenu-meta.xml": "AppMenu",
+    "homepagelayout-meta.xml": "HomePageLayout",
+    # Integration / External
+    "connectedapp-meta.xml": "ConnectedApp",
+    "namedcredential-meta.xml": "NamedCredential",
+    "remotesite-meta.xml": "RemoteSiteSetting",
+    "authprovider-meta.xml": "AuthProvider",
+    "csptrustedsite-meta.xml": "CspTrustedSite",
+    # Email
+    "email-meta.xml": "EmailTemplate",
+    # Agentforce / AI
+    "prompttemplate-meta.xml": "PromptTemplate",
+    "genaiprompttemplate-meta.xml": "GenAiPromptTemplate",
+    "genaifunction-meta.xml": "GenAiFunction",
+    "aiapplication-meta.xml": "AIApplication",
+    "bot-meta.xml": "Bot",
+    "botversion-meta.xml": "BotVersion",
+    # Analytics
+    "wapp-meta.xml": "WaveApplication",
+    "wdash-meta.xml": "WaveDashboard",
+    # Static / Assets
+    "resource-meta.xml": "StaticResource",
+    "asset-meta.xml": "ContentAsset",
+    # Trigger events (code)
+    "trigger-meta.xml": "ApexTrigger",  # companion meta file — skip in practice
+}
+
+# Regex to extract trigger declaration
+APEX_TRIGGER_PATTERN = re.compile(
+    r"trigger\s+(\w+)\s+on\s+(\w+)\s*\(([^)]+)\)",
+    re.IGNORECASE,
+)
+
+# Regex to match @api decorated properties/getters in LWC JS
+LWC_API_PROPERTY_PATTERN = re.compile(r"@api\s+(?:get\s+)?(\w+)", re.MULTILINE)
+
+# Regex to match public (non-underscore-prefixed) methods in LWC JS
+LWC_PUBLIC_METHOD_PATTERN = re.compile(
+    r"^\s{0,4}(?:async\s+)?([a-zA-Z][a-zA-Z0-9_]*)\s*\(([^)]*)\)\s*\{",
+    re.MULTILINE,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -231,7 +313,7 @@ def _parse_apex(source: str) -> dict[str, Any]:
 
 
 # ---------------------------------------------------------------------------
-# XML parsers (field, object)
+# XML parsers (field, object, flow)
 # ---------------------------------------------------------------------------
 
 
@@ -239,6 +321,22 @@ def _extract_xml_tag(xml: str, tag: str) -> str:
     """Extract the first occurrence of a simple XML tag value."""
     m = re.search(rf"<{tag}>(.*?)</{tag}>", xml, re.DOTALL)
     return m.group(1).strip() if m else ""
+
+
+def _extract_xml_attr(xml: str, tag: str, attr: str) -> str:
+    """Extract an attribute value from the first occurrence of an XML tag."""
+    m = re.search(rf'<{tag}\s[^>]*{attr}="([^"]*)"', xml, re.DOTALL | re.IGNORECASE)
+    return m.group(1).strip() if m else ""
+
+
+def _extract_xml_tag_all(xml: str, tag: str) -> list[str]:
+    """Extract all occurrences of a simple XML tag value."""
+    return [m.group(1).strip() for m in re.finditer(rf"<{tag}>(.*?)</{tag}>", xml, re.DOTALL)]
+
+
+def _extract_xml_block_all(xml: str, tag: str) -> list[str]:
+    """Return the raw inner XML of all occurrences of a block tag."""
+    return [m.group(1) for m in re.finditer(rf"<{tag}>(.*?)</{tag}>", xml, re.DOTALL)]
 
 
 def _parse_field_xml(xml: str) -> dict[str, Any]:
@@ -331,7 +429,225 @@ def _parse_flow_xml(xml: str) -> dict[str, Any]:
 
 
 # ---------------------------------------------------------------------------
-# YAML spec builder
+# New parsers — generic helper
+# ---------------------------------------------------------------------------
+
+
+def _parse_generic_xml(xml: str, fields_to_extract: list[str]) -> dict[str, Any]:
+    """
+    Extract a list of tag names from XML and return them as a dict.
+
+    Each entry in fields_to_extract may be:
+      - "tagName"          → extract first value as a string
+      - "tagName[]"        → extract all values as a list
+    """
+    result: dict[str, Any] = {}
+    for field in fields_to_extract:
+        if field.endswith("[]"):
+            tag = field[:-2]
+            result[tag] = _extract_xml_tag_all(xml, tag)
+        else:
+            result[field] = _extract_xml_tag(xml, field)
+    return result
+
+
+def _build_generic_spec(
+    name: str,
+    type_str: str,
+    parsed: dict[str, Any],
+    file_path: Path,
+) -> str:
+    """Build a YAML spec from a generic parsed dict, omitting empty values."""
+    spec: dict[str, Any] = {
+        "component": name,
+        "type": type_str,
+        "file": str(file_path.name),
+    }
+    for k, v in parsed.items():
+        if v or v == 0:  # keep falsy-but-meaningful values like 0
+            if isinstance(v, list) and len(v) == 0:
+                continue
+            spec[k] = v
+    return yaml.dump(spec, allow_unicode=True, default_flow_style=False, sort_keys=False)
+
+
+# ---------------------------------------------------------------------------
+# Specialized new parsers
+# ---------------------------------------------------------------------------
+
+
+def _parse_apex_trigger(source: str) -> dict[str, Any]:
+    """Parse an Apex Trigger source file."""
+    result: dict[str, Any] = {"name": "", "sobject": "", "events": []}
+    m = APEX_TRIGGER_PATTERN.search(source)
+    if m:
+        result["name"] = m.group(1)
+        result["sobject"] = m.group(2)
+        result["events"] = [e.strip() for e in m.group(3).split(",")]
+    return result
+
+
+def _parse_apex_page(source: str, stem: str) -> dict[str, Any]:
+    """Parse a Visualforce Page (.page) file."""
+    controller = _extract_xml_attr(source, r"apex:page", "controller") or _extract_xml_attr(
+        source, r"apex:page", "standardController"
+    )
+    title = _extract_xml_attr(source, r"apex:page", "title")
+    sidebar = _extract_xml_attr(source, r"apex:page", "sidebar")
+    return {
+        "name": stem,
+        "controller": controller,
+        "title": title,
+        "showSidebar": sidebar,
+    }
+
+
+def _parse_apex_component(source: str, stem: str) -> dict[str, Any]:
+    """Parse a Visualforce Component (.component) file."""
+    controller = _extract_xml_attr(source, r"apex:component", "controller")
+    access = _extract_xml_attr(source, r"apex:component", "access")
+    return {"name": stem, "controller": controller, "access": access}
+
+
+def _parse_validation_rule_xml(xml: str) -> dict[str, Any]:
+    """Parse a validationRules block from an object XML."""
+    return {
+        "fullName": _extract_xml_tag(xml, "fullName"),
+        "active": _extract_xml_tag(xml, "active").lower() == "true",
+        "description": _extract_xml_tag(xml, "description"),
+        "errorConditionFormula": _extract_xml_tag(xml, "errorConditionFormula"),
+        "errorMessage": _extract_xml_tag(xml, "errorMessage"),
+    }
+
+
+def _parse_profile_xml(xml: str) -> dict[str, Any]:
+    """Parse a Profile or PermissionSet XML — extract object permissions."""
+    user_license = _extract_xml_tag(xml, "userLicense")
+
+    object_permissions: list[dict[str, Any]] = []
+    for block in _extract_xml_block_all(xml, "objectPermissions"):
+        obj = _extract_xml_tag(block, "object")
+        if obj:
+            object_permissions.append(
+                {
+                    "object": obj,
+                    "read": _extract_xml_tag(block, "allowRead").lower() == "true",
+                    "create": _extract_xml_tag(block, "allowCreate").lower() == "true",
+                    "edit": _extract_xml_tag(block, "allowEdit").lower() == "true",
+                    "delete": _extract_xml_tag(block, "allowDelete").lower() == "true",
+                }
+            )
+
+    user_permissions = _extract_xml_tag_all(xml, "name")  # inside <userPermissions>
+    # Filter to only those inside userPermissions blocks (crude but effective)
+    up_blocks = _extract_xml_block_all(xml, "userPermissions")
+    user_permissions = [_extract_xml_tag(b, "name") for b in up_blocks if _extract_xml_tag(b, "enabled") == "true"]
+
+    return {
+        "userLicense": user_license,
+        "objectPermissions": object_permissions,
+        "enabledUserPermissions": user_permissions,
+    }
+
+
+def _parse_workflow_xml(xml: str) -> dict[str, Any]:
+    """Parse a Workflow metadata XML — extract rules."""
+    rules: list[dict[str, Any]] = []
+    for block in _extract_xml_block_all(xml, "rules"):
+        full_name = _extract_xml_tag(block, "fullName")
+        trigger_type = _extract_xml_tag(block, "triggerType")
+        actions = _extract_xml_tag_all(block, "name")
+        if full_name:
+            rules.append(
+                {"name": full_name, "triggerType": trigger_type, "actionCount": len(actions)}
+            )
+    return {"rules": rules}
+
+
+def _parse_custom_labels_xml(xml: str) -> list[dict[str, Any]]:
+    """Parse a CustomLabels XML file — returns list of label dicts."""
+    labels: list[dict[str, Any]] = []
+    for block in _extract_xml_block_all(xml, "labels"):
+        full_name = _extract_xml_tag(block, "fullName")
+        if full_name:
+            labels.append(
+                {
+                    "fullName": full_name,
+                    "value": _extract_xml_tag(block, "value"),
+                    "language": _extract_xml_tag(block, "language"),
+                    "categories": _extract_xml_tag(block, "categories"),
+                }
+            )
+    return labels
+
+
+def _parse_lwc_bundle(bundle_dir: Path) -> dict[str, Any]:
+    """
+    Parse a Lightning Web Component bundle directory.
+
+    Reads:
+      - *-meta.xml for targets and target configs
+      - *.js for @api properties and public methods
+      - *.html for template root and component references
+    """
+    name = bundle_dir.name
+    result: dict[str, Any] = {
+        "name": name,
+        "targets": [],
+        "apiProperties": [],
+        "publicMethods": [],
+        "componentRefs": [],
+    }
+
+    for f in bundle_dir.iterdir():
+        if f.suffix == ".xml" and f.name.endswith("-meta.xml"):
+            xml = f.read_text(encoding="utf-8", errors="replace")
+            result["targets"] = _extract_xml_tag_all(xml, "target")
+            # Extract @LightningElement property names from targetConfigs
+            result["targetConfigProps"] = _extract_xml_tag_all(xml, "property")
+
+        elif f.suffix == ".js" and not f.name.endswith(".test.js"):
+            js = f.read_text(encoding="utf-8", errors="replace")
+            result["apiProperties"] = LWC_API_PROPERTY_PATTERN.findall(js)
+            # Public methods: top-level, not starting with _
+            pub_methods = []
+            for m in LWC_PUBLIC_METHOD_PATTERN.finditer(js):
+                method_name = m.group(1)
+                if not method_name.startswith("_") and method_name not in {
+                    "constructor", "connectedCallback", "disconnectedCallback",
+                    "renderedCallback", "errorCallback",
+                }:
+                    pub_methods.append(method_name)
+            result["publicMethods"] = list(dict.fromkeys(pub_methods))  # deduplicate
+
+        elif f.suffix == ".html":
+            html = f.read_text(encoding="utf-8", errors="replace")
+            # Find <c-foo>, <lightning-foo> component references
+            refs = re.findall(r"<(c-[\w-]+|lightning-[\w-]+)\b", html)
+            result["componentRefs"] = list(dict.fromkeys(refs))
+
+    return result
+
+
+def _parse_aura_bundle(bundle_dir: Path) -> dict[str, Any]:
+    """Parse an Aura Definition Bundle directory."""
+    name = bundle_dir.name
+    result: dict[str, Any] = {"name": name, "attributes": []}
+
+    for f in bundle_dir.iterdir():
+        if f.suffix in {".cmp", ".app"}:
+            source = f.read_text(encoding="utf-8", errors="replace")
+            # Extract <aura:attribute> name attributes
+            attrs = re.findall(r'<aura:attribute\s[^>]*name="([^"]+)"', source)
+            result["attributes"] = attrs
+            result["bundleType"] = "Application" if f.suffix == ".app" else "Component"
+            break
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# YAML spec builders
 # ---------------------------------------------------------------------------
 
 
@@ -357,6 +673,18 @@ def _build_apex_spec(parsed: dict[str, Any], file_path: Path) -> str:
             method_entry["description"] = m["description"]
         spec["methods"].append(method_entry)
 
+    return yaml.dump(spec, allow_unicode=True, default_flow_style=False, sort_keys=False)
+
+
+def _build_apex_trigger_spec(parsed: dict[str, Any], file_path: Path) -> str:
+    """Convert parsed Apex Trigger data into a YAML spec string."""
+    spec: dict[str, Any] = {
+        "component": parsed["name"] or file_path.stem,
+        "type": "ApexTrigger",
+        "file": str(file_path.name),
+        "sobject": parsed.get("sobject", ""),
+        "events": parsed.get("events", []),
+    }
     return yaml.dump(spec, allow_unicode=True, default_flow_style=False, sort_keys=False)
 
 
@@ -404,6 +732,37 @@ def _build_flow_spec(name: str, parsed: dict[str, Any], file_path: Path) -> str:
     return yaml.dump(spec, allow_unicode=True, default_flow_style=False, sort_keys=False)
 
 
+def _build_lwc_spec(parsed: dict[str, Any], bundle_dir: Path) -> str:
+    """Convert parsed LWC bundle data into a YAML spec string."""
+    spec: dict[str, Any] = {
+        "component": parsed["name"],
+        "type": "LightningComponentBundle",
+        "file": str(bundle_dir.name) + "/",
+    }
+    if parsed.get("targets"):
+        spec["targets"] = parsed["targets"]
+    if parsed.get("apiProperties"):
+        spec["apiProperties"] = parsed["apiProperties"]
+    if parsed.get("publicMethods"):
+        spec["publicMethods"] = parsed["publicMethods"]
+    if parsed.get("componentRefs"):
+        spec["componentRefs"] = parsed["componentRefs"]
+    return yaml.dump(spec, allow_unicode=True, default_flow_style=False, sort_keys=False)
+
+
+def _build_aura_spec(parsed: dict[str, Any], bundle_dir: Path) -> str:
+    """Convert parsed Aura bundle data into a YAML spec string."""
+    spec: dict[str, Any] = {
+        "component": parsed["name"],
+        "type": "AuraDefinitionBundle",
+        "bundleType": parsed.get("bundleType", "Component"),
+        "file": str(bundle_dir.name) + "/",
+    }
+    if parsed.get("attributes"):
+        spec["attributes"] = parsed["attributes"]
+    return yaml.dump(spec, allow_unicode=True, default_flow_style=False, sort_keys=False)
+
+
 # ---------------------------------------------------------------------------
 # Relations graph builder
 # ---------------------------------------------------------------------------
@@ -435,6 +794,28 @@ def _extract_apex_references(source: str, class_name: str) -> list[str]:
 
 
 # ---------------------------------------------------------------------------
+# Suffix detection helper
+# ---------------------------------------------------------------------------
+
+
+def _detect_suffix_type(file_path: Path) -> str | None:
+    """
+    Detect the Salesforce metadata type from a file's compound suffix.
+
+    e.g. "MyFlow.flow-meta.xml" → suffix "flow-meta.xml" → "Flow"
+         "MyPage.page"          → suffix "page" → "ApexPage"
+    Returns None if not recognized.
+    """
+    name = file_path.name.lower()
+    # Try progressively longer suffixes (after the first dot)
+    dot_idx = name.find(".")
+    if dot_idx == -1:
+        return None
+    suffix = name[dot_idx + 1:]
+    return FILE_SUFFIX_TO_TYPE.get(suffix)
+
+
+# ---------------------------------------------------------------------------
 # Main indexer
 # ---------------------------------------------------------------------------
 
@@ -443,9 +824,10 @@ class SalesforceIndexer:
     """
     Differential Salesforce metadata indexer.
 
-    Scans a Salesforce DX project directory, parses Apex classes, custom objects,
-    custom fields, and Flow metadata, then writes compressed YAML specs and a
-    JSON relations graph.
+    Scans a Salesforce DX project directory, parses Apex classes, triggers,
+    pages, components, LWC bundles, Aura bundles, custom objects, custom
+    fields, Flow metadata, and all major Salesforce metadata types, then
+    writes compressed YAML specs and a JSON relations graph.
     """
 
     def __init__(self, project_root: str | Path = ".") -> None:
@@ -489,6 +871,8 @@ class SalesforceIndexer:
         try:
             if suffix == ".cls":
                 return self._index_apex(file_path, name)
+            elif suffix in {".trigger", ".page", ".component"}:
+                return self._index_code_file(file_path, name, suffix)
             elif suffix == ".xml":
                 return self._index_xml(file_path, name)
             else:
@@ -518,13 +902,53 @@ class SalesforceIndexer:
         logger.info("Indexed Apex class: %s (%d methods)", component_name, len(parsed["methods"]))
         return True
 
+    def _index_code_file(self, file_path: Path, stem: str, suffix: str) -> bool:
+        """Index .trigger, .page, or .component files."""
+        source = file_path.read_text(encoding="utf-8", errors="replace")
+
+        if suffix == ".trigger":
+            parsed = _parse_apex_trigger(source)
+            component_name = parsed["name"] or stem
+            yaml_content = _build_apex_trigger_spec(parsed, file_path)
+            self._write_spec(component_name, yaml_content)
+            self._components[component_name] = {
+                "type": "ApexTrigger",
+                "file": str(file_path),
+                "sobject": parsed.get("sobject", ""),
+                "events": parsed.get("events", []),
+            }
+            logger.info(
+                "Indexed Apex trigger: %s (on %s)", component_name, parsed.get("sobject", "?")
+            )
+
+        elif suffix == ".page":
+            parsed_page = _parse_apex_page(source, stem)
+            yaml_content = _build_generic_spec(stem, "ApexPage", parsed_page, file_path)
+            self._write_spec(stem, yaml_content)
+            self._components[stem] = {"type": "ApexPage", "file": str(file_path)}
+            logger.info("Indexed Apex page: %s", stem)
+
+        elif suffix == ".component":
+            parsed_cmp = _parse_apex_component(source, stem)
+            yaml_content = _build_generic_spec(stem, "ApexComponent", parsed_cmp, file_path)
+            self._write_spec(stem, yaml_content)
+            self._components[stem] = {"type": "ApexComponent", "file": str(file_path)}
+            logger.info("Indexed Apex component: %s", stem)
+
+        else:
+            return False
+
+        self.registry.mark_indexed(file_path)
+        return True
+
     def _index_xml(self, file_path: Path, stem: str) -> bool:
         xml = file_path.read_text(encoding="utf-8", errors="replace")
 
-        # Detect type from XML content or path
-        if "<CustomField>" in xml or "<type>" in xml and "<fullName>" in xml and "fields" not in str(file_path.parent.stem):
-            # Field files live in fields/ subdirectory
-            if "fields" in str(file_path).lower() or file_path.parent.name == "fields":
+        # --- Existing detection (preserve all existing logic) ---
+
+        # Field files live in fields/ subdirectory
+        if "fields" in str(file_path).lower() or file_path.parent.name == "fields":
+            if "<CustomField>" in xml or file_path.name.endswith(".field-meta.xml"):
                 return self._index_field(file_path, stem, xml)
 
         if "<CustomObject>" in xml:
@@ -542,6 +966,15 @@ class SalesforceIndexer:
             return self._index_object(file_path, stem, xml)
         elif parent == "flows" or filename.endswith(".flow-meta.xml"):
             return self._index_flow(file_path, stem, xml)
+
+        # --- New: detect by compound suffix ---
+        detected_type = _detect_suffix_type(file_path)
+        if detected_type:
+            return self._index_typed_xml(file_path, stem, xml, detected_type)
+
+        # --- Special: validation rules embedded inside object XML ---
+        if "<validationRules>" in xml:
+            return self._index_validation_rules(file_path, stem, xml)
 
         logger.debug("Unknown XML type, skipping: %s", file_path)
         return False
@@ -603,6 +1036,392 @@ class SalesforceIndexer:
         logger.info("Indexed flow: %s", component_name)
         return True
 
+    def _index_typed_xml(
+        self, file_path: Path, stem: str, xml: str, type_str: str
+    ) -> bool:
+        """
+        Route detected metadata types to their specialized or generic parsers.
+        Returns True if indexed successfully.
+        """
+        component_name = stem
+
+        # ---- Profile / PermissionSet ----
+        if type_str in {"Profile", "PermissionSet"}:
+            parsed = _parse_profile_xml(xml)
+            yaml_content = _build_generic_spec(component_name, type_str, parsed, file_path)
+
+        # ---- PermissionSetGroup ----
+        elif type_str == "PermissionSetGroup":
+            psets = _extract_xml_tag_all(xml, "permissionSets")
+            parsed = {"permissionSets": psets}
+            yaml_content = _build_generic_spec(component_name, type_str, parsed, file_path)
+
+        # ---- WorkflowRule ----
+        elif type_str == "WorkflowRule":
+            parsed_wf = _parse_workflow_xml(xml)
+            yaml_content = _build_generic_spec(component_name, type_str, parsed_wf, file_path)
+
+        # ---- AssignmentRules / EscalationRules / AutoResponseRules ----
+        elif type_str in {"AssignmentRules", "EscalationRules", "AutoResponseRules"}:
+            rule_count = len(_extract_xml_tag_all(xml, "fullName"))
+            parsed = {"ruleCount": rule_count}
+            yaml_content = _build_generic_spec(component_name, type_str, parsed, file_path)
+
+        # ---- SharingRules ----
+        elif type_str == "SharingRules":
+            owner_count = len(re.findall(r"<sharingOwnerRules>", xml))
+            criteria_count = len(re.findall(r"<sharingCriteriaRules>", xml))
+            parsed = {"ownerRuleCount": owner_count, "criteriaRuleCount": criteria_count}
+            yaml_content = _build_generic_spec(component_name, type_str, parsed, file_path)
+
+        # ---- CustomMetadata ----
+        elif type_str == "CustomMetadata":
+            label = _extract_xml_tag(xml, "label")
+            values: list[dict[str, str]] = []
+            for block in _extract_xml_block_all(xml, "values"):
+                field = _extract_xml_tag(block, "field")
+                value = _extract_xml_tag(block, "value")
+                if field:
+                    values.append({"field": field, "value": value})
+            parsed = {"label": label, "values": values}
+            yaml_content = _build_generic_spec(component_name, type_str, parsed, file_path)
+
+        # ---- CustomLabel (labels-meta.xml contains multiple labels) ----
+        elif type_str == "CustomLabel":
+            labels_list = _parse_custom_labels_xml(xml)
+            spec: dict[str, Any] = {
+                "component": component_name,
+                "type": "CustomLabel",
+                "file": str(file_path.name),
+                "labelCount": len(labels_list),
+                "labels": labels_list,
+            }
+            yaml_content = yaml.dump(
+                spec, allow_unicode=True, default_flow_style=False, sort_keys=False
+            )
+
+        # ---- GlobalValueSet ----
+        elif type_str == "GlobalValueSet":
+            entries = _extract_xml_tag_all(xml, "fullName")
+            parsed = {
+                "masterLabel": _extract_xml_tag(xml, "masterLabel"),
+                "values": entries,
+            }
+            yaml_content = _build_generic_spec(component_name, type_str, parsed, file_path)
+
+        # ---- StandardValueSet ----
+        elif type_str == "StandardValueSet":
+            std_entries = _extract_xml_tag_all(xml, "fullName")
+            parsed = {"values": std_entries}
+            yaml_content = _build_generic_spec(component_name, type_str, parsed, file_path)
+
+        # ---- RecordType ----
+        elif type_str == "RecordType":
+            parsed = _parse_generic_xml(
+                xml, ["fullName", "label", "active", "businessProcess"]
+            )
+            yaml_content = _build_generic_spec(component_name, type_str, parsed, file_path)
+
+        # ---- FlexiPage ----
+        elif type_str == "FlexiPage":
+            page_type = _extract_xml_tag(xml, "type")
+            template = _extract_xml_tag(xml, "template")
+            component_refs = _extract_xml_tag_all(xml, "componentName")
+            parsed = {
+                "pageType": page_type,
+                "template": template,
+                "componentCount": len(component_refs),
+                "components": component_refs[:20],  # cap for readability
+            }
+            yaml_content = _build_generic_spec(component_name, type_str, parsed, file_path)
+
+        # ---- Layout ----
+        elif type_str == "Layout":
+            section_count = len(re.findall(r"<layoutSections>", xml))
+            related_count = len(re.findall(r"<relatedLists>", xml))
+            parsed = {"sectionCount": section_count, "relatedListCount": related_count}
+            yaml_content = _build_generic_spec(component_name, type_str, parsed, file_path)
+
+        # ---- CompactLayout ----
+        elif type_str == "CompactLayout":
+            fields = _extract_xml_tag_all(xml, "fields")
+            parsed = {
+                "label": _extract_xml_tag(xml, "label"),
+                "fields": fields,
+            }
+            yaml_content = _build_generic_spec(component_name, type_str, parsed, file_path)
+
+        # ---- ListView ----
+        elif type_str == "ListView":
+            parsed = _parse_generic_xml(
+                xml, ["label", "filterScope", "columns[]"]
+            )
+            yaml_content = _build_generic_spec(component_name, type_str, parsed, file_path)
+
+        # ---- QuickAction ----
+        elif type_str == "QuickAction":
+            parsed = _parse_generic_xml(xml, ["type", "targetObject", "label"])
+            yaml_content = _build_generic_spec(component_name, type_str, parsed, file_path)
+
+        # ---- CustomTab ----
+        elif type_str == "CustomTab":
+            custom_obj = _extract_xml_tag(xml, "customObject")
+            aura_cmp = _extract_xml_tag(xml, "auraComponent")
+            page = _extract_xml_tag(xml, "page")
+            parsed = {
+                "customObject": custom_obj,
+                "auraComponent": aura_cmp,
+                "page": page,
+            }
+            yaml_content = _build_generic_spec(component_name, type_str, parsed, file_path)
+
+        # ---- CustomPermission ----
+        elif type_str == "CustomPermission":
+            parsed = _parse_generic_xml(xml, ["label", "description"])
+            yaml_content = _build_generic_spec(component_name, type_str, parsed, file_path)
+
+        # ---- MatchingRule ----
+        elif type_str == "MatchingRule":
+            item_count = len(re.findall(r"<matchingRuleItems>", xml))
+            active = _extract_xml_tag(xml, "active")
+            parsed = {"active": active, "matchingRuleItemCount": item_count}
+            yaml_content = _build_generic_spec(component_name, type_str, parsed, file_path)
+
+        # ---- DuplicateRule ----
+        elif type_str == "DuplicateRule":
+            matching_rules = _extract_xml_tag_all(xml, "matchingRule")
+            parsed = {
+                "masterLabel": _extract_xml_tag(xml, "masterLabel"),
+                "isActive": _extract_xml_tag(xml, "isActive"),
+                "matchingRules": matching_rules,
+            }
+            yaml_content = _build_generic_spec(component_name, type_str, parsed, file_path)
+
+        # ---- CustomApplication ----
+        elif type_str == "CustomApplication":
+            tabs = _extract_xml_tag_all(xml, "tabs")
+            parsed = {
+                "label": _extract_xml_tag(xml, "label"),
+                "navType": _extract_xml_tag(xml, "navType"),
+                "tabCount": len(tabs),
+                "tabs": tabs,
+            }
+            yaml_content = _build_generic_spec(component_name, type_str, parsed, file_path)
+
+        # ---- AppMenu ----
+        elif type_str == "AppMenu":
+            item_count = len(re.findall(r"<appMenuItems>", xml))
+            parsed = {"appMenuItemCount": item_count}
+            yaml_content = _build_generic_spec(component_name, type_str, parsed, file_path)
+
+        # ---- HomePageLayout ----
+        elif type_str == "HomePageLayout":
+            components = _extract_xml_tag_all(xml, "homePageComponents")
+            parsed = {"componentCount": len(components), "components": components}
+            yaml_content = _build_generic_spec(component_name, type_str, parsed, file_path)
+
+        # ---- ConnectedApp ----
+        elif type_str == "ConnectedApp":
+            scopes = _extract_xml_tag_all(xml, "scopes")
+            parsed = {
+                "label": _extract_xml_tag(xml, "label"),
+                "scopes": scopes,
+            }
+            yaml_content = _build_generic_spec(component_name, type_str, parsed, file_path)
+
+        # ---- NamedCredential ----
+        elif type_str == "NamedCredential":
+            parsed = _parse_generic_xml(xml, ["label", "endpoint", "principalType"])
+            yaml_content = _build_generic_spec(component_name, type_str, parsed, file_path)
+
+        # ---- RemoteSiteSetting ----
+        elif type_str == "RemoteSiteSetting":
+            parsed = _parse_generic_xml(xml, ["url", "isActive", "description"])
+            yaml_content = _build_generic_spec(component_name, type_str, parsed, file_path)
+
+        # ---- AuthProvider ----
+        elif type_str == "AuthProvider":
+            parsed = _parse_generic_xml(xml, ["providerType", "friendlyName"])
+            yaml_content = _build_generic_spec(component_name, type_str, parsed, file_path)
+
+        # ---- CspTrustedSite ----
+        elif type_str == "CspTrustedSite":
+            parsed = _parse_generic_xml(xml, ["endpointUrl", "isActive"])
+            yaml_content = _build_generic_spec(component_name, type_str, parsed, file_path)
+
+        # ---- EmailTemplate ----
+        elif type_str == "EmailTemplate":
+            parsed = _parse_generic_xml(xml, ["name", "subject", "type", "description"])
+            yaml_content = _build_generic_spec(component_name, type_str, parsed, file_path)
+
+        # ---- PromptTemplate ----
+        elif type_str == "PromptTemplate":
+            active_count = len(re.findall(r"<activeVersions>", xml))
+            parsed = {
+                "masterLabel": _extract_xml_tag(xml, "masterLabel"),
+                "type": _extract_xml_tag(xml, "type"),
+                "templateType": _extract_xml_tag(xml, "templateType"),
+                "activeVersionCount": active_count,
+            }
+            yaml_content = _build_generic_spec(component_name, type_str, parsed, file_path)
+
+        # ---- GenAiPromptTemplate ----
+        elif type_str == "GenAiPromptTemplate":
+            parsed = _parse_generic_xml(xml, ["masterLabel", "type"])
+            yaml_content = _build_generic_spec(component_name, type_str, parsed, file_path)
+
+        # ---- GenAiFunction ----
+        elif type_str == "GenAiFunction":
+            parsed = _parse_generic_xml(
+                xml, ["masterLabel", "description", "functionDefinition"]
+            )
+            yaml_content = _build_generic_spec(component_name, type_str, parsed, file_path)
+
+        # ---- AIApplication ----
+        elif type_str == "AIApplication":
+            parsed = _parse_generic_xml(xml, ["developerName", "status"])
+            yaml_content = _build_generic_spec(component_name, type_str, parsed, file_path)
+
+        # ---- Bot / BotVersion ----
+        elif type_str in {"Bot", "BotVersion"}:
+            dialog_count = len(re.findall(r"<mlSlotClass>|<dialog>|<dialogNode>", xml))
+            parsed = {
+                "label": _extract_xml_tag(xml, "label"),
+                "logPrivateConversationData": _extract_xml_tag(xml, "logPrivateConversationData"),
+                "dialogCount": dialog_count,
+            }
+            yaml_content = _build_generic_spec(component_name, type_str, parsed, file_path)
+
+        # ---- WaveApplication / WaveDashboard ----
+        elif type_str in {"WaveApplication", "WaveDashboard"}:
+            parsed = _parse_generic_xml(xml, ["name", "label"])
+            yaml_content = _build_generic_spec(component_name, type_str, parsed, file_path)
+
+        # ---- StaticResource ----
+        elif type_str == "StaticResource":
+            parsed = _parse_generic_xml(xml, ["contentType", "cacheControl", "description"])
+            yaml_content = _build_generic_spec(component_name, type_str, parsed, file_path)
+
+        # ---- ContentAsset ----
+        elif type_str == "ContentAsset":
+            parsed = _parse_generic_xml(xml, ["masterLabel", "language"])
+            yaml_content = _build_generic_spec(component_name, type_str, parsed, file_path)
+
+        # ---- Fallback for remaining mapped types ----
+        else:
+            yaml_content = _build_generic_spec(
+                component_name, type_str, {"fullName": stem}, file_path
+            )
+
+        self._write_spec(component_name, yaml_content)
+        self._components[component_name] = {
+            "type": type_str,
+            "file": str(file_path),
+        }
+        self.registry.mark_indexed(file_path)
+        logger.info("Indexed %s: %s", type_str, component_name)
+        return True
+
+    def _index_validation_rules(self, file_path: Path, stem: str, xml: str) -> bool:
+        """Index validationRules embedded inside an object XML file."""
+        count = 0
+        for block in _extract_xml_block_all(xml, "validationRules"):
+            parsed = _parse_validation_rule_xml(block)
+            rule_name = parsed.get("fullName") or ""
+            if not rule_name:
+                continue
+            component_name = f"{stem}.{rule_name}"
+            spec: dict[str, Any] = {
+                "component": component_name,
+                "type": "ValidationRule",
+                "file": str(file_path.name),
+                "active": parsed.get("active", False),
+                "description": parsed.get("description", ""),
+                "errorMessage": parsed.get("errorMessage", ""),
+                "errorConditionFormula": parsed.get("errorConditionFormula", ""),
+            }
+            yaml_content = yaml.dump(
+                spec, allow_unicode=True, default_flow_style=False, sort_keys=False
+            )
+            self._write_spec(component_name, yaml_content)
+            self._components[component_name] = {
+                "type": "ValidationRule",
+                "file": str(file_path),
+                "active": parsed.get("active", False),
+            }
+            count += 1
+        if count > 0:
+            self.registry.mark_indexed(file_path)
+            logger.info("Indexed %d validation rule(s) from: %s", count, file_path.name)
+            return True
+        return False
+
+    def _index_lwc_bundle(self, bundle_dir: Path) -> bool:
+        """Index a Lightning Web Component bundle directory."""
+        if not self.registry.is_stale(bundle_dir / f"{bundle_dir.name}.js") and any(
+            (bundle_dir / f"{bundle_dir.name}.js").exists() for _ in [None]
+        ):
+            # Check any relevant file in bundle for staleness
+            pass
+
+        # Always index if any file in the bundle has changed
+        any_stale = any(
+            self.registry.is_stale(f)
+            for f in bundle_dir.iterdir()
+            if f.is_file()
+        )
+        if not any_stale:
+            logger.debug("Skipping unchanged LWC bundle: %s", bundle_dir)
+            return False
+
+        try:
+            parsed = _parse_lwc_bundle(bundle_dir)
+            yaml_content = _build_lwc_spec(parsed, bundle_dir)
+            component_name = f"lwc__{parsed['name']}"
+            self._write_spec(component_name, yaml_content)
+            self._components[component_name] = {
+                "type": "LightningComponentBundle",
+                "file": str(bundle_dir),
+            }
+            # Mark all files in the bundle as indexed
+            for f in bundle_dir.iterdir():
+                if f.is_file():
+                    self.registry.mark_indexed(f)
+            logger.info("Indexed LWC bundle: %s", parsed["name"])
+            return True
+        except Exception as exc:
+            logger.error("Failed to index LWC bundle %s: %s", bundle_dir, exc)
+            return False
+
+    def _index_aura_bundle(self, bundle_dir: Path) -> bool:
+        """Index an Aura Definition Bundle directory."""
+        any_stale = any(
+            self.registry.is_stale(f)
+            for f in bundle_dir.iterdir()
+            if f.is_file()
+        )
+        if not any_stale:
+            logger.debug("Skipping unchanged Aura bundle: %s", bundle_dir)
+            return False
+
+        try:
+            parsed = _parse_aura_bundle(bundle_dir)
+            yaml_content = _build_aura_spec(parsed, bundle_dir)
+            component_name = f"aura__{parsed['name']}"
+            self._write_spec(component_name, yaml_content)
+            self._components[component_name] = {
+                "type": "AuraDefinitionBundle",
+                "file": str(bundle_dir),
+            }
+            for f in bundle_dir.iterdir():
+                if f.is_file():
+                    self.registry.mark_indexed(f)
+            logger.info("Indexed Aura bundle: %s", parsed["name"])
+            return True
+        except Exception as exc:
+            logger.error("Failed to index Aura bundle %s: %s", bundle_dir, exc)
+            return False
+
     def _build_relations(self) -> None:
         """Build the nodes+edges graph from indexed components."""
         nodes = []
@@ -660,8 +1479,8 @@ class SalesforceIndexer:
 
         counters = {"indexed": 0, "skipped": 0, "errors": 0}
 
-        # Walk all .cls and .xml files
-        extensions = {".cls", ".xml"}
+        # Walk all .cls, .xml, .trigger, .page, .component files
+        extensions = {".cls", ".xml", ".trigger", ".page", ".component"}
         for root, dirs, files in os.walk(search_root):
             # Skip hidden directories and node_modules
             dirs[:] = [d for d in dirs if not d.startswith(".") and d != "node_modules"]
@@ -670,7 +1489,7 @@ class SalesforceIndexer:
                 if file_path.suffix.lower() not in extensions:
                     continue
                 # Skip meta.xml companion files for Apex (they carry no useful info)
-                if fname.endswith(".cls-meta.xml"):
+                if fname.endswith(".cls-meta.xml") or fname.endswith(".trigger-meta.xml"):
                     continue
                 try:
                     result = self.index_file(file_path)
@@ -681,6 +1500,36 @@ class SalesforceIndexer:
                 except Exception as exc:
                     logger.error("Error indexing %s: %s", file_path, exc)
                     counters["errors"] += 1
+
+        # Scan LWC bundles
+        lwc_root = search_root / "main" / "default" / "lwc"
+        if lwc_root.exists():
+            for bundle_dir in lwc_root.iterdir():
+                if bundle_dir.is_dir():
+                    try:
+                        result = self._index_lwc_bundle(bundle_dir)
+                        if result:
+                            counters["indexed"] += 1
+                        else:
+                            counters["skipped"] += 1
+                    except Exception as exc:
+                        logger.error("Error indexing LWC bundle %s: %s", bundle_dir, exc)
+                        counters["errors"] += 1
+
+        # Scan Aura bundles
+        aura_root = search_root / "main" / "default" / "aura"
+        if aura_root.exists():
+            for bundle_dir in aura_root.iterdir():
+                if bundle_dir.is_dir():
+                    try:
+                        result = self._index_aura_bundle(bundle_dir)
+                        if result:
+                            counters["indexed"] += 1
+                        else:
+                            counters["skipped"] += 1
+                    except Exception as exc:
+                        logger.error("Error indexing Aura bundle %s: %s", bundle_dir, exc)
+                        counters["errors"] += 1
 
         self._build_relations()
         self._save_relations()

--- a/rtk_sf/mcp_server.py
+++ b/rtk_sf/mcp_server.py
@@ -113,6 +113,41 @@ _TOOLS: list[dict[str, Any]] = [
             },
         },
     },
+    {
+        "name": "annotate_component",
+        "description": (
+            "Record a discovered business rule, condition, or context note on a component. "
+            "Use this after finding logic in source code (e.g. an if-condition, SOQL filter, "
+            "access rule) so the knowledge is searchable without re-reading the source file. "
+            "Annotations are immediately indexed and returned by query_compressed_spec."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "component_name": {
+                    "type": "string",
+                    "description": "Exact component name to annotate (e.g. 'Application__c').",
+                },
+                "key": {
+                    "type": "string",
+                    "description": (
+                        "Short category label for the annotation. "
+                        "Examples: 'business_rule', 'condition', 'access_rule', 'soql_filter', 'validation'."
+                    ),
+                },
+                "value": {
+                    "type": "string",
+                    "description": "Full description of the discovered logic or context.",
+                },
+                "source": {
+                    "type": "string",
+                    "description": "Origin of this annotation (default: 'ai_discovery').",
+                    "default": "ai_discovery",
+                },
+            },
+            "required": ["component_name", "key", "value"],
+        },
+    },
 ]
 
 
@@ -204,6 +239,8 @@ class MCPServer:
                 result = self._tool_get_relations(arguments)
             elif tool_name == "list_components":
                 result = self._tool_list_components(arguments)
+            elif tool_name == "annotate_component":
+                result = self._tool_annotate(arguments)
             else:
                 self._write(self._error(request_id, -32601, f"Unknown tool: {tool_name}"))
                 return
@@ -232,12 +269,56 @@ class MCPServer:
                 best = results[0]
                 spec = best.get("yaml_spec") or search.get_spec(best["name"])
                 if spec:
-                    return f"# Closest match: {best['name']}\n\n{spec}"
+                    component_name = best["name"]
+                    annotations = search.get_annotations(component_name)
+                    return self._format_spec_with_annotations(
+                        f"# Closest match: {component_name}\n\n{spec}",
+                        annotations,
+                    )
             return (
                 f"Component '{component_name}' not found in index.\n"
                 "Run `rtk-sf index` to update the index."
             )
-        return spec
+
+        annotations = search.get_annotations(component_name)
+        return self._format_spec_with_annotations(spec, annotations)
+
+    @staticmethod
+    def _format_spec_with_annotations(spec: str, annotations: list) -> str:
+        if not annotations:
+            return spec
+        lines = [spec, "", "## Annotations (discovered business logic)", ""]
+        for a in annotations:
+            import datetime
+            ts = datetime.datetime.fromtimestamp(a["created_at"]).strftime("%Y-%m-%d")
+            lines.append(f"[{a['key']}] ({a['source']} · {ts})")
+            lines.append(f"  {a['value']}")
+            lines.append("")
+        return "\n".join(lines)
+
+    def _tool_annotate(self, args: dict) -> str:
+        component_name = args.get("component_name", "").strip()
+        key = args.get("key", "").strip()
+        value = args.get("value", "").strip()
+        source = args.get("source", "ai_discovery").strip() or "ai_discovery"
+
+        if not component_name or not key or not value:
+            return "Error: component_name, key, and value are all required."
+
+        search = self._get_search()
+        ok = search.add_annotation(component_name, key, value, source)
+        if ok:
+            return (
+                f"Annotation saved on '{component_name}'.\n"
+                f"  key    : {key}\n"
+                f"  source : {source}\n"
+                f"  value  : {value}\n\n"
+                f"This is now searchable via search_codebase and included in query_compressed_spec."
+            )
+        return (
+            f"Component '{component_name}' not found in index. "
+            "Run `rtk-sf index` first."
+        )
 
     def _tool_search(self, args: dict) -> str:
         query = args.get("query", "").strip()

--- a/rtk_sf/search.py
+++ b/rtk_sf/search.py
@@ -83,7 +83,8 @@ CREATE VIRTUAL TABLE IF NOT EXISTS components_fts USING fts5(
     type,
     raw_text,
     content='components',
-    content_rowid='id'
+    content_rowid='id',
+    tokenize="trigram"
 );
 
 CREATE TABLE IF NOT EXISTS embeddings (
@@ -91,6 +92,17 @@ CREATE TABLE IF NOT EXISTS embeddings (
     vocab_json   TEXT NOT NULL,
     vector_json  TEXT NOT NULL
 );
+
+CREATE TABLE IF NOT EXISTS annotations (
+    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    component_id INTEGER NOT NULL REFERENCES components(id) ON DELETE CASCADE,
+    key          TEXT NOT NULL,
+    value        TEXT NOT NULL,
+    source       TEXT NOT NULL DEFAULT 'manual',
+    created_at   REAL NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_annotations_component ON annotations(component_id);
 
 -- Triggers to keep FTS in sync
 CREATE TRIGGER IF NOT EXISTS components_ai AFTER INSERT ON components BEGIN
@@ -244,6 +256,92 @@ class SearchEngine:
         conn.commit()
 
     # ------------------------------------------------------------------
+    # Annotations — reverse-record discovered business logic
+    # ------------------------------------------------------------------
+
+    def add_annotation(
+        self,
+        component_name: str,
+        key: str,
+        value: str,
+        source: str = "manual",
+    ) -> bool:
+        """
+        Record a discovered business rule or context note on a component.
+
+        The annotation text is appended to the component's FTS raw_text so
+        it becomes searchable immediately without a full re-index.
+
+        Args:
+            component_name: Exact component name (e.g. "Application__c").
+            key: Short label for the annotation (e.g. "business_rule", "condition").
+            value: Free-text description of the discovered logic.
+            source: Origin tag (e.g. "ai_discovery", "manual", "code_review").
+
+        Returns:
+            True if the annotation was saved; False if component not found.
+        """
+        import time
+
+        conn = self._get_conn()
+        row = conn.execute(
+            "SELECT id FROM components WHERE name = ?", (component_name,)
+        ).fetchone()
+        if not row:
+            return False
+
+        component_id = row["id"]
+        conn.execute(
+            "INSERT INTO annotations (component_id, key, value, source, created_at) VALUES (?, ?, ?, ?, ?)",
+            (component_id, key, value, source, time.time()),
+        )
+
+        # Append annotation text to raw_text so FTS index reflects it
+        combined = f"\n\n[annotation:{key}] {value}"
+        conn.execute(
+            "UPDATE components SET raw_text = raw_text || ? WHERE id = ?",
+            (combined.lower(), component_id),
+        )
+        conn.execute(
+            "UPDATE components_fts SET raw_text = raw_text || ? WHERE rowid = ?",
+            (combined.lower(), component_id),
+        )
+
+        conn.commit()
+        return True
+
+    def get_annotations(self, component_name: str) -> list[dict[str, Any]]:
+        """
+        Return all annotations for a component.
+
+        Args:
+            component_name: Exact component name.
+
+        Returns:
+            List of dicts with keys: key, value, source, created_at.
+        """
+        conn = self._get_conn()
+        rows = conn.execute(
+            """
+            SELECT a.key, a.value, a.source, a.created_at
+            FROM annotations a
+            JOIN components c ON c.id = a.component_id
+            WHERE c.name = ?
+            ORDER BY a.created_at ASC
+            """,
+            (component_name,),
+        ).fetchall()
+        return [
+            {
+                "key": r["key"],
+                "value": r["value"],
+                "source": r["source"],
+                "created_at": r["created_at"],
+            }
+            for r in rows
+        ]
+
+    # ------------------------------------------------------------------
     # Search
     # ------------------------------------------------------------------
 
@@ -263,24 +361,8 @@ class SearchEngine:
         """
         conn = self._get_conn()
 
-        # Sanitize query for FTS5 (escape double-quotes)
-        safe_query = query.replace('"', '""')
-
-        try:
-            rows = conn.execute(
-                """
-                SELECT c.name, c.type, c.file_path, c.yaml_spec, c.raw_text,
-                       fts.rank AS fts_score
-                FROM components_fts fts
-                JOIN components c ON c.id = fts.rowid
-                WHERE components_fts MATCH ?
-                ORDER BY fts.rank
-                LIMIT ?
-                """,
-                (safe_query, limit * 3),  # over-fetch for re-ranking
-            ).fetchall()
-        except sqlite3.OperationalError:
-            # FTS5 query syntax error — fall back to LIKE search
+        # Trigram FTS5 needs ≥3 characters; use LIKE directly for short queries
+        if len(query.strip()) < 3:
             like_q = f"%{query}%"
             rows = conn.execute(
                 """
@@ -291,6 +373,35 @@ class SearchEngine:
                 """,
                 (like_q, like_q, limit * 3),
             ).fetchall()
+        else:
+            # Sanitize query for FTS5 (escape double-quotes)
+            safe_query = query.replace('"', '""')
+
+            try:
+                rows = conn.execute(
+                    """
+                    SELECT c.name, c.type, c.file_path, c.yaml_spec, c.raw_text,
+                           fts.rank AS fts_score
+                    FROM components_fts fts
+                    JOIN components c ON c.id = fts.rowid
+                    WHERE components_fts MATCH ?
+                    ORDER BY fts.rank
+                    LIMIT ?
+                    """,
+                    (safe_query, limit * 3),  # over-fetch for re-ranking
+                ).fetchall()
+            except sqlite3.OperationalError:
+                # FTS5 query syntax error — fall back to LIKE search
+                like_q = f"%{query}%"
+                rows = conn.execute(
+                    """
+                    SELECT name, type, file_path, yaml_spec, raw_text, 0 AS fts_score
+                    FROM components
+                    WHERE name LIKE ? OR raw_text LIKE ?
+                    LIMIT ?
+                    """,
+                    (like_q, like_q, limit * 3),
+                ).fetchall()
 
         results: list[dict[str, Any]] = []
         for row in rows:
@@ -444,6 +555,38 @@ class SearchEngine:
             "downstream": downstream,
         }
 
+    @staticmethod
+    def _camel_split(text: str) -> str:
+        """
+        Insert spaces before uppercase letters to split camelCase/PascalCase
+        identifiers into searchable words.
+
+        Example: "ExamTicketDownloadController" → "Exam Ticket Download Controller"
+        """
+        import re
+        # Insert space before uppercase letter followed by lowercase
+        spaced = re.sub(r"(?<=[a-z0-9])([A-Z])", r" \1", text)
+        # Insert space between consecutive uppercase and then lowercase (e.g. XMLParser)
+        spaced = re.sub(r"([A-Z]+)([A-Z][a-z])", r"\1 \2", spaced)
+        # Also split on underscores and hyphens
+        spaced = re.sub(r"[_\-]", " ", spaced)
+        return spaced
+
+    def _build_raw_text(self, name: str, yaml_text: str) -> str:
+        """
+        Build an FTS-friendly raw text blob from YAML spec + split identifiers.
+
+        Appends camelCase-split versions of all identifiers so that FTS5 can
+        match individual word fragments (e.g. 'exam' matches
+        'ExamTicketDownloadController').
+        """
+        import re
+        # Extract all identifiers from the YAML
+        identifiers = re.findall(r"[A-Za-z][A-Za-z0-9_]{3,}", yaml_text)
+        unique = list(dict.fromkeys(identifiers))
+        split_words = " ".join(self._camel_split(ident) for ident in unique[:200])
+        return f"{yaml_text}\n\n{split_words}".lower()
+
     def sync_from_specs(self) -> int:
         """
         Populate the SQLite database from YAML spec files on disk.
@@ -468,13 +611,13 @@ class SearchEngine:
                 component_type = data.get("type", "Unknown")
                 file_path = data.get("file", "")
 
-                # Use YAML as both spec and raw text for FTS
+                raw_text = self._build_raw_text(name, yaml_text)
                 self.upsert_component(
                     name=name,
                     component_type=component_type,
                     file_path=file_path,
                     yaml_spec=yaml_text,
-                    raw_text=yaml_text,
+                    raw_text=raw_text,
                     updated_at=spec_file.stat().st_mtime,
                 )
                 count += 1

--- a/rtk_sf/ui_generator.py
+++ b/rtk_sf/ui_generator.py
@@ -24,7 +24,7 @@ RELATIONS_FILE = "relations.json"
 SPECS_DIR = "specs"
 
 # Cytoscape.js CDN URL (loaded inline via CDN; no bundling required)
-CYTOSCAPE_CDN = "https://cdnjs.cloudflare.com/ajax/libs/cytoscape/3.28.1/cytoscape.min.js"
+CYTOSCAPE_CDN = "https://cdnjs.cloudflare.com/ajax/libs/cytoscape/3.34.2/cytoscape.min.js"
 
 # furuCRM brand colors
 COLOR_PRIMARY = "#0066cc"

--- a/rtk_sf/watcher.py
+++ b/rtk_sf/watcher.py
@@ -29,8 +29,8 @@ except ImportError:
     )
 
 
-WATCHED_EXTENSIONS = {".cls", ".xml"}
-IGNORED_SUFFIXES = {".cls-meta.xml"}
+WATCHED_EXTENSIONS = {".cls", ".xml", ".trigger", ".page", ".component"}
+IGNORED_SUFFIXES = {".cls-meta.xml", ".trigger-meta.xml"}
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -150,7 +150,7 @@ print_next_steps() {
   echo ""
   info "Docs: https://github.com/furuCRM/rtk-sf"
   echo ""
-  echo -e "Built with love by ${BOLD}furuCRM Inc.${NC} — https://furucrm.com"
+  echo -e "Built with love by ${BOLD}furuCRM Inc.${NC} — https://www.furucrm.com"
   echo ""
 }
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2,7 +2,7 @@
 # install.sh — One-command rtk-sf setup for Salesforce DX projects.
 #
 # Usage:
-#   curl -sSL https://raw.githubusercontent.com/furuCRM/rtk-sf/main/scripts/install.sh | bash
+#   curl -sSL https://raw.githubusercontent.com/furuCRM-Inc/rtk-sf/main/scripts/install.sh | bash
 #
 # Or locally:
 #   chmod +x scripts/install.sh && ./scripts/install.sh
@@ -148,7 +148,7 @@ print_next_steps() {
   echo "  4. Re-index after adding new Apex classes or objects:"
   echo -e "     ${BOLD}rtk-sf index${NC}"
   echo ""
-  info "Docs: https://github.com/furuCRM/rtk-sf"
+  info "Docs: https://github.com/furuCRM-Inc/rtk-sf"
   echo ""
   echo -e "Built with love by ${BOLD}furuCRM Inc.${NC} — https://www.furucrm.com"
   echo ""


### PR DESCRIPTION
## Summary

- **`annotate_component` MCP tool** — AI agents write discovered business logic back to the index; persists across sessions at zero token cost
- **Japanese full-text search** — FTS5 trigram + LIKE fallback for <3-char terms (`申込`, `不備`, `選考` all searchable)
- **CamelCase splitting** — `ExamTicketDownloadController` → searchable by `Exam`, `Ticket`, `Download`, `Controller`
- **44+ metadata types** — full sf CLI coverage (Agentforce, OmniStudio, Experience Cloud, Analytics)
- **README viral launch** — Before/After comparison, team ROI calculator, `curl` one-liner, Contributing asks

## What Changed

| File | Change |
|---|---|
| `rtk_sf/search.py` | `annotations` table, `add_annotation()`, `get_annotations()`, trigram FTS5, LIKE fallback for short queries |
| `rtk_sf/mcp_server.py` | 5th MCP tool `annotate_component`; annotations in `query_compressed_spec` response |
| `rtk_sf/indexer.py` | 44 metadata types; CamelCase splitting via `_build_raw_text()` |
| `rtk_sf/__init__.py` | Version → 0.3.0 |
| `rtk_sf/__main__.py` | `--version` reads `__version__` dynamically |
| `rtk_sf/ui_generator.py` | Cytoscape CDN 3.28.1 → 3.34.2 |
| `pyproject.toml` | All deps to latest; version → 0.3.0; `cline` keyword → `claude-code` |
| `README.md` | Before/After table, ROI calculator, curl one-liner, Japanese search docs, Cline removed |
| `scripts/install.sh` | URL fix → `https://www.furucrm.com` |

## Test Plan

- [x] 69/70 automated checks passed across all modules
- [x] Japanese 2-char LIKE: `申込`, `不備`, `選考` return results
- [x] Japanese 3-char trigram: `主任教諭`, `管理職`, `不備修正` return results  
- [x] CamelCase: `search("ApplicationSubmission")` → `ApplicationSubmissionController`
- [x] `annotate_component` → stored → searchable → returned in `query_compressed_spec`
- [x] All 5 MCP tools via JSON-RPC 2.0 dispatch
- [x] `rtk-sf index` differential (743 skipped, 0 errors)
- [x] `rtk-sf ui` → 391KB HTML with Cytoscape SVG
- [x] `rtk-sf --version` → `rtk-sf 0.3.0`

## Launch Checklist (post-merge)

- [ ] Create GitHub release v0.3.0
- [ ] Publish to PyPI
- [ ] SFXD Discord `#ai-and-automation`
- [ ] r/salesforce + r/SalesforceDeveloper
- [ ] LinkedIn with ROI calculator screenshot
- [ ] X/Twitter `#SalesforceDevs #ClaudeCode #Apex`
- [ ] Pin Before/After screen recording GIF to README top

🤖 Generated with [Claude Code](https://claude.com/claude-code)