### PR TITLE
feat(v0.5.0): NLP compactor, dry-run engine, ROI tracker, OCR interceptor, one-command install

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,9 +117,7 @@ This checks Python, installs rtk-sf, indexes your project, and prints your next 
 **Step 1 — Install**
 
 ```bash
-pip install git+https://github.com/furuCRM-Inc/rtk-sf.git@main
-# With vector re-ranking (optional):
-pip install "git+https://github.com/furuCRM-Inc/rtk-sf.git@main[vector]"
+pip install "git+https://github.com/furuCRM-Inc/rtk-sf.git@main#egg=rtk-sf[all]"
 ```
 
 **Step 2 — Index your Salesforce project**
@@ -258,7 +256,7 @@ Re-index (3 changed) : ~0.1 seconds
 
 ### Hybrid Search
 
-Keyword search uses SQLite's built-in **FTS5** full-text search — no external dependencies, no network calls. When `numpy` is installed (`pip install "git+https://github.com/furuCRM-Inc/rtk-sf.git@main[vector]"`), results are re-ranked using bag-of-words cosine similarity for improved relevance.
+Keyword search uses SQLite's built-in **FTS5** full-text search — no external dependencies, no network calls. When `numpy` is installed (included in the `[all]` bundle), results are re-ranked using bag-of-words cosine similarity for improved relevance.
 
 **Japanese search is fully supported.** rtk-sf uses the FTS5 `trigram` tokenizer combined with a LIKE fallback for 1–2 character terms, so Japanese metadata labels, picklist values, and annotation text are all searchable:
 
@@ -487,16 +485,21 @@ rtk-sf indexes all major Salesforce metadata types supported by the sf CLI, grou
 
 ## Installation
 
-### From GitHub
+### One command (recommended)
 
 ```bash
-pip install git+https://github.com/furuCRM-Inc/rtk-sf.git@main
+pip install "git+https://github.com/furuCRM-Inc/rtk-sf.git@main#egg=rtk-sf[all]"
 ```
 
-### With vector re-ranking
+Includes: core indexer + vector re-ranking (numpy) + local OCR (paddleocr + Pillow)
+
+### À la carte
 
 ```bash
-pip install "git+https://github.com/furuCRM-Inc/rtk-sf.git@main[vector]"
+pip install "git+https://github.com/furuCRM-Inc/rtk-sf.git@main"                        # core only
+pip install "git+https://github.com/furuCRM-Inc/rtk-sf.git@main#egg=rtk-sf[vector]"     # + vector re-ranking
+pip install "git+https://github.com/furuCRM-Inc/rtk-sf.git@main#egg=rtk-sf[ocr]"        # + PaddleOCR (EN+JA)
+pip install "git+https://github.com/furuCRM-Inc/rtk-sf.git@main#egg=rtk-sf[ocr-fallback]" # + EasyOCR fallback
 ```
 
 ### From source

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ This checks Python, installs rtk-sf, indexes your project, and prints your next 
 **Step 1 — Install**
 
 ```bash
-pip install "git+https://github.com/furuCRM-Inc/rtk-sf.git@main#egg=rtk-sf[all]"
+pip install "rtk-sf[all] @ git+https://github.com/furuCRM-Inc/rtk-sf.git@main"
 ```
 
 **Step 2 — Index your Salesforce project**
@@ -488,7 +488,7 @@ rtk-sf indexes all major Salesforce metadata types supported by the sf CLI, grou
 ### One command (recommended)
 
 ```bash
-pip install "git+https://github.com/furuCRM-Inc/rtk-sf.git@main#egg=rtk-sf[all]"
+pip install "rtk-sf[all] @ git+https://github.com/furuCRM-Inc/rtk-sf.git@main"
 ```
 
 Includes: core indexer + vector re-ranking (numpy) + local OCR (paddleocr + Pillow)
@@ -496,10 +496,10 @@ Includes: core indexer + vector re-ranking (numpy) + local OCR (paddleocr + Pill
 ### À la carte
 
 ```bash
-pip install "git+https://github.com/furuCRM-Inc/rtk-sf.git@main"                        # core only
-pip install "git+https://github.com/furuCRM-Inc/rtk-sf.git@main#egg=rtk-sf[vector]"     # + vector re-ranking
-pip install "git+https://github.com/furuCRM-Inc/rtk-sf.git@main#egg=rtk-sf[ocr]"        # + PaddleOCR (EN+JA)
-pip install "git+https://github.com/furuCRM-Inc/rtk-sf.git@main#egg=rtk-sf[ocr-fallback]" # + EasyOCR fallback
+pip install "git+https://github.com/furuCRM-Inc/rtk-sf.git@main"                                    # core only
+pip install "rtk-sf[vector] @ git+https://github.com/furuCRM-Inc/rtk-sf.git@main"                   # + vector re-ranking
+pip install "rtk-sf[ocr] @ git+https://github.com/furuCRM-Inc/rtk-sf.git@main"                      # + PaddleOCR (EN+JA)
+pip install "rtk-sf[ocr-fallback] @ git+https://github.com/furuCRM-Inc/rtk-sf.git@main"             # + EasyOCR fallback
 ```
 
 ### From source

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Synced 84 components into search index.
 **Step 3 — Register with Claude Code**
 
 ```bash
-claude mcp add rtk-sf -- python -m rtk_sf serve
+claude mcp add rtk-sf -- python3 -m rtk_sf serve
 ```
 
 **Step 4 — Tell Claude to use rtk-sf (critical)**
@@ -184,7 +184,7 @@ Your AI agent now has instant, token-efficient access to your entire Salesforce 
 
 ```bash
 # Register the MCP server (run once per project)
-claude mcp add rtk-sf -- python -m rtk_sf serve
+claude mcp add rtk-sf -- python3 -m rtk_sf serve
 
 # Verify
 claude mcp list
@@ -211,7 +211,7 @@ Claude: What calls AccountService?
 
 ```bash
 # Start the server manually
-python -m rtk_sf serve
+python3 -m rtk_sf serve
 
 # The server reads JSON-RPC 2.0 from stdin, writes to stdout
 # Protocol: MCP 2024-11-05

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "rtk-sf"
-version = "0.4.1"
+version = "0.5.0"
 description = "Zero-Token Knowledge & Visual Live-Mapping Layer for Salesforce AI Agents"
 readme = "README.md"
 license = { text = "MIT" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ dependencies = [
 vector = ["numpy>=2.5.2"]
 ocr = ["paddleocr", "Pillow"]
 ocr-fallback = ["easyocr", "Pillow"]
+all = ["numpy>=2.5.2", "paddleocr", "Pillow"]
 dev = [
     "pytest>=9.1.1",
     "pytest-cov>=7.1.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,8 @@ dependencies = [
 
 [project.optional-dependencies]
 vector = ["numpy>=2.5.2"]
+ocr = ["paddleocr", "Pillow"]
+ocr-fallback = ["easyocr", "Pillow"]
 dev = [
     "pytest>=9.1.1",
     "pytest-cov>=7.1.0",

--- a/rtk_sf/__init__.py
+++ b/rtk_sf/__init__.py
@@ -6,7 +6,7 @@ compressed YAML specs and serves them via MCP to AI agents like Claude Code and 
 dramatically reducing token consumption.
 """
 
-__version__ = "0.4.1"
+__version__ = "0.5.0"
 __author__ = "furuCRM Inc."
 __email__ = "contact@furucrm.com"
 __license__ = "MIT"

--- a/rtk_sf/__main__.py
+++ b/rtk_sf/__main__.py
@@ -23,7 +23,8 @@ import sys
 from pathlib import Path
 
 # CLAUDE.md markers used by install and upgrade detection
-_MARKER_V4 = "get_class_skeleton"
+_MARKER_V5 = "get_roi_stats"        # v0.5-only tool — confirms full 14-tool block
+_MARKER_V4 = "get_class_skeleton"   # v0.4 tool — present but missing 5 new v0.5 tools
 _MARKER_BASE = "## Code Search"
 
 
@@ -54,13 +55,16 @@ def _detect_sf_source(project_root: Path) -> Path | None:
 def _patch_claude_md(project_root: Path) -> None:
     claude_md = project_root / "CLAUDE.md"
 
-    if claude_md.exists() and _MARKER_V4 in claude_md.read_text(encoding="utf-8"):
-        _success("CLAUDE.md already has rtk-sf v0.4+ instructions. Skipping.")
+    if claude_md.exists() and _MARKER_V5 in claude_md.read_text(encoding="utf-8"):
+        _success("CLAUDE.md already has rtk-sf v0.5 instructions. Skipping.")
         return
 
-    # Strip old v0.3 block if present
+    # Strip old block (v0.3 or v0.4) if present, then rewrite with full v0.5 tool list
     if claude_md.exists() and _MARKER_BASE in claude_md.read_text(encoding="utf-8"):
-        _warn("Upgrading CLAUDE.md from v0.3 to v0.5 tool list...")
+        if _MARKER_V4 in claude_md.read_text(encoding="utf-8"):
+            _warn("Upgrading CLAUDE.md from v0.4 to v0.5 tool list (5 new tools)...")
+        else:
+            _warn("Upgrading CLAUDE.md from v0.3 to v0.5 tool list...")
         lines = claude_md.read_text(encoding="utf-8").splitlines()
         in_block = False
         kept: list[str] = []

--- a/rtk_sf/__main__.py
+++ b/rtk_sf/__main__.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import argparse
 import logging
+import shutil
 import sys
 from pathlib import Path
 

--- a/rtk_sf/__main__.py
+++ b/rtk_sf/__main__.py
@@ -2,14 +2,16 @@
 __main__.py — CLI entry point for rtk-sf.
 
 Supports subcommands:
+    install — Full one-command setup: index + patch CLAUDE.md + print next steps
     index   — Index a Salesforce DX project
     watch   — Watch for file changes and re-index incrementally
     serve   — Start the MCP stdio JSON-RPC server
     ui      — Generate the architecture map HTML
 
 Usage:
+    python -m rtk_sf install            # run after pip install
     python -m rtk_sf <subcommand> [options]
-    rtk-sf <subcommand> [options]      (when installed via pip)
+    rtk-sf <subcommand> [options]       (when installed via pip)
 """
 
 from __future__ import annotations
@@ -18,6 +20,137 @@ import argparse
 import logging
 import sys
 from pathlib import Path
+
+# CLAUDE.md markers used by install and upgrade detection
+_MARKER_V4 = "get_class_skeleton"
+_MARKER_BASE = "## Code Search"
+
+
+def _info(msg: str) -> None:
+    print(f"\033[34m[rtk-sf]\033[0m {msg}")
+
+def _success(msg: str) -> None:
+    print(f"\033[32m[rtk-sf]\033[0m {msg}")
+
+def _warn(msg: str) -> None:
+    print(f"\033[33m[rtk-sf]\033[0m {msg}")
+
+def _bold(msg: str) -> None:
+    print(f"\033[1m{msg}\033[0m")
+
+
+def _detect_sf_source(project_root: Path) -> Path | None:
+    if (project_root / "force-app").is_dir():
+        return project_root / "force-app"
+    src = project_root / "src"
+    if src.is_dir() and any(src.rglob("*.cls")):
+        return src
+    if any(project_root.rglob("*.cls")):
+        return project_root
+    return None
+
+
+def _patch_claude_md(project_root: Path) -> None:
+    claude_md = project_root / "CLAUDE.md"
+
+    if claude_md.exists() and _MARKER_V4 in claude_md.read_text(encoding="utf-8"):
+        _success("CLAUDE.md already has rtk-sf v0.4+ instructions. Skipping.")
+        return
+
+    # Strip old v0.3 block if present
+    if claude_md.exists() and _MARKER_BASE in claude_md.read_text(encoding="utf-8"):
+        _warn("Upgrading CLAUDE.md from v0.3 to v0.5 tool list...")
+        lines = claude_md.read_text(encoding="utf-8").splitlines()
+        in_block = False
+        kept: list[str] = []
+        for line in lines:
+            if line.startswith(_MARKER_BASE):
+                in_block = True
+            elif in_block and line.startswith("## "):
+                in_block = False
+            if not in_block:
+                kept.append(line)
+        claude_md.write_text("\n".join(kept), encoding="utf-8")
+
+    block = """
+## Code Search & Data — Use rtk-sf First (Required)
+
+This project is indexed by **rtk-sf**. Always use the MCP tools before reading raw files or calling sf CLI:
+
+| Task | Tool to call |
+|---|---|
+| Find a component by name or keyword | `search_codebase(query)` |
+| Read a component spec / fields / methods | `query_compressed_spec(component_name)` |
+| Blast-radius before editing | `get_relations(component_name)` |
+| List all Apex classes / objects / flows | `list_components(type)` |
+| Write discovered business logic back | `annotate_component(component_name, key, value)` |
+| Read an Apex class before editing (surgical) | `get_class_skeleton(component_name, focus_methods)` |
+| Deploy / retrieve / run tests silently | `sf_command(action, target_org, ...)` |
+| Get object field list for data creation | `get_object_schema(object_name)` |
+| Inspect existing records (sample only) | `soql_query(query, target_org, sample_size)` |
+| Compact a bilingual prompt before sending | `compact_prompt(text)` |
+| Dry-run Apex code before deploy | `validate_apex(code)` |
+| Dry-run SOQL before executing | `validate_soql(query)` |
+| Extract text from a screenshot/image | `extract_image_text(image_path)` |
+| View token/dollar savings this session | `get_roi_stats()` |
+
+**Never** do these directly — use the tool instead:
+- Read a raw .cls file       → `get_class_skeleton`
+- sf sobject describe        → `get_object_schema`
+- sf data query              → `soql_query`
+- sf project deploy start    → `sf_command(action="deploy")`
+
+If search returns no results, re-index with: `python -m rtk_sf index`
+Do NOT use `npx rtk-sf` — rtk-sf is a Python package, not npm.
+"""
+
+    if claude_md.exists():
+        original = claude_md.read_text(encoding="utf-8")
+        first_line, _, rest = original.partition("\n")
+        claude_md.write_text(f"{first_line}\n{block}\n{rest}", encoding="utf-8")
+        _success("CLAUDE.md updated with rtk-sf tool instructions.")
+    else:
+        claude_md.write_text(f"# Salesforce Project\n{block}\n", encoding="utf-8")
+        _success("CLAUDE.md created with rtk-sf tool instructions.")
+
+
+def _print_next_steps() -> None:
+    import shutil
+    python_cmd = "python3" if shutil.which("python3") else "python"
+
+    print()
+    _bold("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
+    _bold("  rtk-sf is ready!")
+    _bold("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
+    print()
+    _info("Next steps:")
+    print()
+    print("  1. Register with Claude Code:")
+    print(f"     \033[1mclaude mcp add rtk-sf -- {python_cmd} -m rtk_sf serve\033[0m")
+    print()
+    print("  2. Generate the visual architecture map:")
+    print(f"     \033[1m{python_cmd} -m rtk_sf ui\033[0m")
+    print(f"     \033[1mopen dist/architecture_map.html\033[0m")
+    print()
+    print("  3. Enable live file watching during development:")
+    print(f"     \033[1m{python_cmd} -m rtk_sf watch\033[0m")
+    print()
+    print("  4. Re-index after adding new Apex classes or objects:")
+    print(f"     \033[1m{python_cmd} -m rtk_sf index\033[0m")
+    print()
+
+    if not shutil.which("rtk-sf"):
+        import sysconfig
+        scripts_dir = sysconfig.get_path("scripts")
+        if scripts_dir:
+            _warn("'rtk-sf' CLI not in PATH. Add it permanently:")
+            print(f'     \033[1mexport PATH="$PATH:{scripts_dir}"\033[0m')
+            print()
+
+    _info("Docs: https://github.com/furuCRM-Inc/rtk-sf")
+    print()
+    print(f"Built with love by \033[1mfuruCRM Inc.\033[0m — https://www.furucrm.com")
+    print()
 
 
 def _setup_logging(verbose: bool) -> None:
@@ -28,6 +161,59 @@ def _setup_logging(verbose: bool) -> None:
         datefmt="%H:%M:%S",
         stream=sys.stderr,
     )
+
+
+# ---------------------------------------------------------------------------
+# Subcommand: install (full setup)
+# ---------------------------------------------------------------------------
+
+
+def cmd_setup(args: argparse.Namespace) -> int:
+    """Full one-command setup: detect project, index, patch CLAUDE.md, print next steps."""
+    from rtk_sf.indexer import SalesforceIndexer
+    from rtk_sf.search import SearchEngine
+    from rtk_sf import __version__
+
+    project_root = Path(args.project_root).resolve()
+
+    print()
+    _bold("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
+    _bold(f"  rtk-sf {__version__} — setup")
+    _bold("  Zero-Token Knowledge Layer for Salesforce AI Agents")
+    _bold("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
+    print()
+
+    # Step 1: detect Salesforce source directory
+    sf_source = _detect_sf_source(project_root)
+    if sf_source:
+        _success(f"Salesforce source detected: {sf_source.relative_to(project_root)}/")
+    else:
+        _warn("No Apex (.cls) files found. Indexing project root.")
+        sf_source = None
+
+    # Step 2: index
+    _info("Indexing Salesforce metadata...")
+    indexer = SalesforceIndexer(project_root)
+    counters = indexer.index_project(sf_source)
+    _success(
+        f"Index complete — "
+        f"{counters['indexed']} indexed, "
+        f"{counters['skipped']} skipped, "
+        f"{counters['errors']} errors."
+    )
+
+    if counters["indexed"] > 0:
+        with SearchEngine(project_root) as engine:
+            synced = engine.sync_from_specs()
+        _success(f"Search index ready: {synced} components.")
+
+    # Step 3: patch CLAUDE.md
+    _patch_claude_md(project_root)
+
+    # Step 4: next steps
+    _print_next_steps()
+
+    return 0 if counters["errors"] == 0 else 1
 
 
 # ---------------------------------------------------------------------------
@@ -159,6 +345,13 @@ Built by furuCRM Inc. — https://www.furucrm.com
 
     subparsers = parser.add_subparsers(dest="command", metavar="COMMAND")
     subparsers.required = True
+
+    # install (full setup)
+    p_setup = subparsers.add_parser(
+        "install",
+        help="Full setup: index project + patch CLAUDE.md + print MCP registration steps",
+    )
+    p_setup.set_defaults(func=cmd_setup)
 
     # index
     p_index = subparsers.add_parser("index", help="Index Salesforce metadata")

--- a/rtk_sf/__main__.py
+++ b/rtk_sf/__main__.py
@@ -9,8 +9,8 @@ Supports subcommands:
     ui      — Generate the architecture map HTML
 
 Usage:
-    python -m rtk_sf install            # run after pip install
-    python -m rtk_sf <subcommand> [options]
+    python3 -m rtk_sf install            # run after pip install
+    python3 -m rtk_sf <subcommand> [options]
     rtk-sf <subcommand> [options]       (when installed via pip)
 """
 
@@ -100,7 +100,7 @@ This project is indexed by **rtk-sf**. Always use the MCP tools before reading r
 - sf data query              → `soql_query`
 - sf project deploy start    → `sf_command(action="deploy")`
 
-If search returns no results, re-index with: `python -m rtk_sf index`
+If search returns no results, re-index with: `python3 -m rtk_sf index`
 Do NOT use `npx rtk-sf` — rtk-sf is a Python package, not npm.
 """
 
@@ -115,8 +115,7 @@ Do NOT use `npx rtk-sf` — rtk-sf is a Python package, not npm.
 
 
 def _print_next_steps() -> None:
-    import shutil
-    python_cmd = "python3" if shutil.which("python3") else "python"
+    python_cmd = "python3"
 
     print()
     _bold("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
@@ -324,7 +323,7 @@ Examples:
   rtk-sf ui --output ~/Desktop/map.html
 
 MCP integration:
-  claude mcp add rtk-sf -- python -m rtk_sf serve
+  claude mcp add rtk-sf -- python3 -m rtk_sf serve
 
 Built by furuCRM Inc. — https://www.furucrm.com
 """,

--- a/rtk_sf/dry_run.py
+++ b/rtk_sf/dry_run.py
@@ -1,0 +1,260 @@
+"""
+dry_run.py — Local Apex/SOQL syntax validation + session ROI tracker.
+
+Two responsibilities:
+
+1. Dry-run engine
+   validate_apex(code)  — regex-based checks for common Apex pitfalls
+   validate_soql(query) — SOQL structure and governor limit checks
+   No org call, no network, instant feedback.
+
+2. ROI tracker
+   record_savings(op, raw_tokens, compressed_tokens)
+   get_roi_stats() → formatted summary of tokens + dollars saved this session
+
+   Token cost baseline: Claude Sonnet 4 @ $3 per 1M input tokens.
+   Called automatically by mcp_server.py on each suppression tool.
+"""
+
+from __future__ import annotations
+
+import re
+import time
+from dataclasses import dataclass, field
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# ROI Tracker
+# ---------------------------------------------------------------------------
+
+_TOKEN_COST_PER_MILLION = 3.0  # USD — Claude Sonnet 4 input price
+
+@dataclass
+class _RoiSession:
+    tokens_saved: int = 0
+    dollars_saved: float = 0.0
+    operations: list[dict[str, Any]] = field(default_factory=list)
+    start_time: float = field(default_factory=time.time)
+
+_session = _RoiSession()
+
+
+def record_savings(operation: str, raw_tokens: int, compressed_tokens: int) -> None:
+    """
+    Record a token-saving operation into the session tracker.
+
+    Args:
+        operation:        Short label, e.g. 'query_compressed_spec'
+        raw_tokens:       Estimated tokens if the raw file had been read
+        compressed_tokens: Actual tokens returned by the tool
+    """
+    saved = max(0, raw_tokens - compressed_tokens)
+    dollars = saved * _TOKEN_COST_PER_MILLION / 1_000_000
+    _session.tokens_saved += saved
+    _session.dollars_saved += dollars
+    _session.operations.append({
+        "op": operation,
+        "raw": raw_tokens,
+        "compressed": compressed_tokens,
+        "saved": saved,
+        "dollars": round(dollars, 6),
+    })
+
+
+def get_roi_stats() -> str:
+    """Return a visual terminal summary of tokens and dollars saved this session."""
+    elapsed = int(time.time() - _session.start_time)
+    minutes, secs = divmod(elapsed, 60)
+    duration = f"{minutes}m {secs}s" if minutes else f"{secs}s"
+
+    lines = [
+        "── rtk-sf ROI Tracker ──────────────────────────────",
+        f"  Tokens saved this session : {_session.tokens_saved:>10,}",
+        f"  Dollars saved this session: ${_session.dollars_saved:>9.4f}",
+        f"  Suppression operations    : {len(_session.operations):>10}",
+        f"  Session duration          : {duration:>10}",
+        "─────────────────────────────────────────────────────",
+    ]
+
+    if _session.operations:
+        lines.append("  Last 5 operations:")
+        for op in _session.operations[-5:]:
+            lines.append(
+                f"    {op['op']:<30}  {op['saved']:>6,} tokens  (${op['dollars']:.4f})"
+            )
+
+    if not _session.operations:
+        lines.append("  No suppression operations recorded yet this session.")
+
+    lines.append(
+        "\n  Token cost basis: Claude Sonnet 4 @ $3.00 / 1M input tokens"
+    )
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Apex Dry-Run Engine
+# ---------------------------------------------------------------------------
+
+_APEX_RULES: list[tuple[re.Pattern[str], str, str]] = [
+    (
+        re.compile(r"\bfor\b[^{]*\{[^}]*\bSELECT\b", re.IGNORECASE | re.DOTALL),
+        "ERROR",
+        "SOQL inside a for-loop — governor limit violation (use a List and query before the loop)",
+    ),
+    (
+        re.compile(r"\bfor\b[^{]*\{[^}]*\b(insert|update|delete|upsert|merge|undelete)\b",
+                   re.IGNORECASE | re.DOTALL),
+        "ERROR",
+        "DML inside a for-loop — use a List and bulk DML outside the loop",
+    ),
+    (
+        re.compile(r"\bSystem\.debug\s*\(", re.IGNORECASE),
+        "WARN",
+        "System.debug() found — remove before production deploy",
+    ),
+    (
+        re.compile(r"//\s*TODO\b", re.IGNORECASE),
+        "WARN",
+        "TODO comment found — resolve before merging",
+    ),
+    (
+        re.compile(r"\bDatabase\.(insert|update|delete|upsert)\s*\([^,)]+\)\s*;", re.IGNORECASE),
+        "INFO",
+        "Database DML without allOrNone param — consider explicit error handling",
+    ),
+    (
+        re.compile(r"@future\s*\([^)]*\)\s*public\s+static\s+void\s+\w+\s*\([^)]*(?<!\bString\b)[^)]*\)",
+                   re.IGNORECASE),
+        "WARN",
+        "@future method with non-primitive/non-String parameter — only primitives and String allowed",
+    ),
+]
+
+
+def validate_apex(code: str) -> str:
+    """
+    Run regex-based Apex dry-run checks locally. No org call, instant.
+
+    Checks for:
+    - SOQL / DML inside loops (governor limit violations)
+    - System.debug in production code
+    - TODO comments
+    - Unbalanced braces / unclosed strings
+    - @future parameter type constraints
+
+    Args:
+        code: Apex class or method source code string
+
+    Returns:
+        Formatted dry-run report.
+    """
+    issues: list[tuple[str, str]] = []
+
+    for pattern, level, message in _APEX_RULES:
+        if pattern.search(code):
+            issues.append((level, message))
+
+    # Structural checks
+    opens = code.count("{")
+    closes = code.count("}")
+    if opens != closes:
+        issues.append(("ERROR", f"Unbalanced braces: {opens} '{{' vs {closes} '}}'"))
+
+    # Rough unclosed string check (count unescaped single quotes)
+    sq_count = len(re.findall(r"(?<!\\)'", code))
+    if sq_count % 2 != 0:
+        issues.append(("WARN", "Odd single-quote count — possible unclosed string literal"))
+
+    errors = [m for l, m in issues if l == "ERROR"]
+    warns  = [m for l, m in issues if l == "WARN"]
+    infos  = [m for l, m in issues if l == "INFO"]
+
+    lines = ["── Apex Dry-Run Report ──────────────────────────────"]
+    if not issues:
+        lines.append("  ✓  No issues detected")
+    else:
+        for msg in errors:
+            lines.append(f"  ✗  [ERROR] {msg}")
+        for msg in warns:
+            lines.append(f"  ⚠  [WARN]  {msg}")
+        for msg in infos:
+            lines.append(f"  ℹ  [INFO]  {msg}")
+        lines.append(f"\n  {len(errors)} error(s), {len(warns)} warning(s), {len(infos)} info(s)")
+
+    lines.append("  Note: regex check only — deploy to sandbox to catch compile errors")
+    lines.append("─────────────────────────────────────────────────────")
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# SOQL Dry-Run Engine
+# ---------------------------------------------------------------------------
+
+def validate_soql(query: str) -> str:
+    """
+    Run basic SOQL structure and governor limit checks locally. No org call.
+
+    Checks for:
+    - SELECT / FROM presence
+    - SELECT * (not supported in SOQL)
+    - LIMIT > 50,000 (governor limit)
+    - Unbalanced parentheses
+    - Date literal typos (common ones)
+
+    Args:
+        query: SOQL query string
+
+    Returns:
+        Formatted dry-run report.
+    """
+    q = query.strip()
+    issues: list[tuple[str, str]] = []
+
+    if not re.match(r"\bSELECT\b", q, re.IGNORECASE):
+        issues.append(("ERROR", "Query must start with SELECT"))
+
+    if not re.search(r"\bFROM\b", q, re.IGNORECASE):
+        issues.append(("ERROR", "Missing FROM clause"))
+
+    if re.search(r"\bSELECT\s+\*", q, re.IGNORECASE):
+        issues.append(("ERROR", "SELECT * is not supported in SOQL — list field API names explicitly"))
+
+    limit_match = re.search(r"\bLIMIT\s+(\d+)\b", q, re.IGNORECASE)
+    if limit_match:
+        limit_val = int(limit_match.group(1))
+        if limit_val > 50_000:
+            issues.append(("ERROR", f"LIMIT {limit_val:,} exceeds SOQL governor limit (50,000)"))
+        elif limit_val > 10_000:
+            issues.append(("WARN", f"LIMIT {limit_val:,} is large — consider paginating with OFFSET"))
+
+    opens = q.count("(")
+    closes = q.count(")")
+    if opens != closes:
+        issues.append(("ERROR", f"Unbalanced parentheses: {opens} '(' vs {closes} ')'"))
+
+    # Date literal typos
+    bad_dates = re.findall(r"\bTODAY\(\)|LAST_N_DAYS\b(?!\s*:\s*\d)", q, re.IGNORECASE)
+    for bd in bad_dates:
+        issues.append(("WARN", f"Possible date literal syntax error near '{bd}'"))
+
+    # No WHERE on a large query
+    if not re.search(r"\bWHERE\b", q, re.IGNORECASE) and not limit_match:
+        issues.append(("WARN", "No WHERE clause and no LIMIT — this will fetch all records"))
+
+    errors = [m for l, m in issues if l == "ERROR"]
+    warns  = [m for l, m in issues if l == "WARN"]
+
+    lines = ["── SOQL Dry-Run Report ───────────────────────────────"]
+    if not issues:
+        lines.append("  ✓  Basic syntax looks valid")
+    else:
+        for msg in errors:
+            lines.append(f"  ✗  [ERROR] {msg}")
+        for msg in warns:
+            lines.append(f"  ⚠  [WARN]  {msg}")
+        lines.append(f"\n  {len(errors)} error(s), {len(warns)} warning(s)")
+
+    lines.append("  Note: regex check only — execute against sandbox to validate fully")
+    lines.append("─────────────────────────────────────────────────────")
+    return "\n".join(lines)

--- a/rtk_sf/indexer.py
+++ b/rtk_sf/indexer.py
@@ -7,7 +7,7 @@ into compressed YAML specs. Uses mtime-based differential tracking so only
 changed files are re-indexed.
 
 Usage:
-    python -m rtk_sf index [--path ./force-app]
+    python3 -m rtk_sf index [--path ./force-app]
 """
 
 from __future__ import annotations

--- a/rtk_sf/mcp_server.py
+++ b/rtk_sf/mcp_server.py
@@ -490,10 +490,13 @@ class MCPServer:
                 if spec:
                     component_name = best["name"]
                     annotations = search.get_annotations(component_name)
-                    return self._format_spec_with_annotations(
+                    result = self._format_spec_with_annotations(
                         f"# Closest match: {component_name}\n\n{spec}",
                         annotations,
                     )
+                    from rtk_sf.dry_run import record_savings
+                    record_savings("query_compressed_spec", raw_tokens=4000, compressed_tokens=len(result) // 4)
+                    return result
             return (
                 f"Component '{component_name}' not found in index.\n"
                 "Run `rtk-sf index` to update the index."
@@ -610,6 +613,8 @@ class MCPServer:
                 best = hits[0]["name"]
                 result = skeleton_from_spec(best, rtk_dir, focus_methods)
                 if result:
+                    from rtk_sf.dry_run import record_savings
+                    record_savings("get_class_skeleton", raw_tokens=10000, compressed_tokens=len(result) // 4)
                     return f"# Closest match: {best}\n\n{result}"
             return (
                 f"Component '{component_name}' not found or is not an Apex class.\n"

--- a/rtk_sf/mcp_server.py
+++ b/rtk_sf/mcp_server.py
@@ -15,6 +15,10 @@ Tools exposed:
     sf_command(action, ...)                     → silent sf CLI execution (v0.4.0)
     get_object_schema(object_name)              → compact data-generation profile (v0.4.1)
     soql_query(query, target_org, ..)           → SOQL with auto row truncation (v0.4.1)
+    compact_prompt(text)                        → bilingual NLP prompt compactor (v0.5.0)
+    validate_apex(code)                         → local Apex dry-run check (v0.5.0)
+    validate_soql(query)                        → local SOQL dry-run check (v0.5.0)
+    get_roi_stats()                             → session token/dollar savings report (v0.5.0)
 
 Protocol:
     - Reads JSON-RPC 2.0 requests line-by-line from stdin.
@@ -243,6 +247,76 @@ _TOOLS: list[dict[str, Any]] = [
         },
     },
     {
+        "name": "compact_prompt",
+        "description": (
+            "Strip conversational noise from a bilingual (English + Japanese) prompt "
+            "before routing it to the AI engine. Removes polite fillers, pleasantries, "
+            "and grammatical particles while preserving Salesforce API names, method names, "
+            "and all structural parameters. "
+            "Token impact: a 200-token polite request → ~80-token intent payload."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "text": {
+                    "type": "string",
+                    "description": "Raw user prompt text to compact (English, Japanese, or mixed).",
+                }
+            },
+            "required": ["text"],
+        },
+    },
+    {
+        "name": "validate_apex",
+        "description": (
+            "Run a local regex-based dry-run check on Apex code before deploying to sandbox. "
+            "Detects: SOQL/DML inside loops, System.debug calls, TODO comments, "
+            "unbalanced braces, unclosed strings, and @future parameter type violations. "
+            "Zero org calls — instant feedback."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "code": {
+                    "type": "string",
+                    "description": "Apex class or method source code to validate.",
+                }
+            },
+            "required": ["code"],
+        },
+    },
+    {
+        "name": "validate_soql",
+        "description": (
+            "Run a local regex-based dry-run check on a SOQL query before executing against an org. "
+            "Detects: missing SELECT/FROM, SELECT *, LIMIT > 50,000, unbalanced parentheses, "
+            "missing WHERE+LIMIT (full-table scan risk), and date literal syntax errors. "
+            "Zero org calls — instant feedback."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "query": {
+                    "type": "string",
+                    "description": "SOQL query string to validate.",
+                }
+            },
+            "required": ["query"],
+        },
+    },
+    {
+        "name": "get_roi_stats",
+        "description": (
+            "Return a visual terminal summary of tokens and dollars saved this session "
+            "by using rtk-sf suppression tools instead of raw file reads or org calls. "
+            "Tracks: query_compressed_spec, get_class_skeleton, get_object_schema, soql_query."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {},
+        },
+    },
+    {
         "name": "annotate_component",
         "description": (
             "Record a discovered business rule, condition, or context note on a component. "
@@ -378,6 +452,14 @@ class MCPServer:
                 result = self._tool_get_object_schema(arguments)
             elif tool_name == "soql_query":
                 result = self._tool_soql_query(arguments)
+            elif tool_name == "compact_prompt":
+                result = self._tool_compact_prompt(arguments)
+            elif tool_name == "validate_apex":
+                result = self._tool_validate_apex(arguments)
+            elif tool_name == "validate_soql":
+                result = self._tool_validate_soql(arguments)
+            elif tool_name == "get_roi_stats":
+                result = self._tool_get_roi_stats()
             else:
                 self._write(self._error(request_id, -32601, f"Unknown tool: {tool_name}"))
                 return
@@ -418,7 +500,10 @@ class MCPServer:
             )
 
         annotations = search.get_annotations(component_name)
-        return self._format_spec_with_annotations(spec, annotations)
+        result = self._format_spec_with_annotations(spec, annotations)
+        from rtk_sf.dry_run import record_savings
+        record_savings("query_compressed_spec", raw_tokens=4000, compressed_tokens=len(result) // 4)
+        return result
 
     @staticmethod
     def _format_spec_with_annotations(spec: str, annotations: list) -> str:
@@ -438,19 +523,50 @@ class MCPServer:
         if not object_name:
             return "Error: object_name is required."
         from rtk_sf.data_tools import get_object_schema
+        from rtk_sf.dry_run import record_savings
         rtk_dir = self.project_root / ".rtk-sf"
-        return get_object_schema(object_name, rtk_dir)
+        result = get_object_schema(object_name, rtk_dir)
+        record_savings("get_object_schema", raw_tokens=5000, compressed_tokens=len(result) // 4)
+        return result
 
     def _tool_soql_query(self, args: dict) -> str:
         query = args.get("query", "").strip()
         if not query:
             return "Error: query is required."
         from rtk_sf.data_tools import run_soql
-        return run_soql(
+        from rtk_sf.dry_run import record_savings
+        result = run_soql(
             query=query,
             target_org=args.get("target_org"),
             sample_size=int(args.get("sample_size", 3)),
         )
+        record_savings("soql_query", raw_tokens=8000, compressed_tokens=len(result) // 4)
+        return result
+
+    def _tool_compact_prompt(self, args: dict) -> str:
+        text = args.get("text", "").strip()
+        if not text:
+            return "Error: text is required."
+        from rtk_sf.nlp_compactor import compact_prompt_report
+        return compact_prompt_report(text)
+
+    def _tool_validate_apex(self, args: dict) -> str:
+        code = args.get("code", "").strip()
+        if not code:
+            return "Error: code is required."
+        from rtk_sf.dry_run import validate_apex
+        return validate_apex(code)
+
+    def _tool_validate_soql(self, args: dict) -> str:
+        query = args.get("query", "").strip()
+        if not query:
+            return "Error: query is required."
+        from rtk_sf.dry_run import validate_soql
+        return validate_soql(query)
+
+    def _tool_get_roi_stats(self) -> str:
+        from rtk_sf.dry_run import get_roi_stats
+        return get_roi_stats()
 
     def _tool_annotate(self, args: dict) -> str:
         component_name = args.get("component_name", "").strip()
@@ -499,6 +615,8 @@ class MCPServer:
                 f"Component '{component_name}' not found or is not an Apex class.\n"
                 "Run `rtk-sf index` to update the index."
             )
+        from rtk_sf.dry_run import record_savings
+        record_savings("get_class_skeleton", raw_tokens=10000, compressed_tokens=len(result) // 4)
         return result
 
     def _tool_sf_command(self, args: dict) -> str:

--- a/rtk_sf/mcp_server.py
+++ b/rtk_sf/mcp_server.py
@@ -19,6 +19,7 @@ Tools exposed:
     validate_apex(code)                         → local Apex dry-run check (v0.5.0)
     validate_soql(query)                        → local SOQL dry-run check (v0.5.0)
     get_roi_stats()                             → session token/dollar savings report (v0.5.0)
+    extract_image_text(image_path)             → local OCR — bypasses vision tokens (v0.5.0)
 
 Protocol:
     - Reads JSON-RPC 2.0 requests line-by-line from stdin.
@@ -317,6 +318,36 @@ _TOOLS: list[dict[str, Any]] = [
         },
     },
     {
+        "name": "extract_image_text",
+        "description": (
+            "Extract English and Japanese text from an image file using local OCR — "
+            "bypassing Claude's multimodal vision token cost entirely. "
+            "Uses PaddleOCR (primary) or EasyOCR (fallback). "
+            "Supports: .png .jpg .jpeg .bmp .tiff .webp. "
+            "Token impact: a 1280×800 screenshot costs ~1,600 vision tokens as an image; "
+            "this returns the extracted text at ~100–300 tokens instead. "
+            "Use this when the user attaches a screenshot, mockup, error dialog, or form image."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "image_path": {
+                    "type": "string",
+                    "description": "Absolute or relative path to the image file.",
+                },
+                "preprocess": {
+                    "type": "boolean",
+                    "description": (
+                        "Apply grayscale + contrast boost before OCR. "
+                        "Helps with low-contrast screenshots or dark-mode UIs (default true)."
+                    ),
+                    "default": True,
+                },
+            },
+            "required": ["image_path"],
+        },
+    },
+    {
         "name": "annotate_component",
         "description": (
             "Record a discovered business rule, condition, or context note on a component. "
@@ -460,6 +491,8 @@ class MCPServer:
                 result = self._tool_validate_soql(arguments)
             elif tool_name == "get_roi_stats":
                 result = self._tool_get_roi_stats()
+            elif tool_name == "extract_image_text":
+                result = self._tool_extract_image_text(arguments)
             else:
                 self._write(self._error(request_id, -32601, f"Unknown tool: {tool_name}"))
                 return
@@ -570,6 +603,20 @@ class MCPServer:
     def _tool_get_roi_stats(self) -> str:
         from rtk_sf.dry_run import get_roi_stats
         return get_roi_stats()
+
+    def _tool_extract_image_text(self, args: dict) -> str:
+        image_path = args.get("image_path", "").strip()
+        if not image_path:
+            return "Error: image_path is required."
+        preprocess = bool(args.get("preprocess", True))
+        from rtk_sf.vision_ocr import extract_image_text
+        from rtk_sf.dry_run import record_savings
+        result = extract_image_text(image_path, preprocess=preprocess)
+        if not result.startswith("[rtk-sf OCR Error") and not result.startswith("[rtk-sf OCR:"):
+            # Successful extraction — record vision token savings
+            # Baseline: typical screenshot ~1,500 vision tokens; extracted text ~100-300 tokens
+            record_savings("extract_image_text", raw_tokens=1500, compressed_tokens=len(result) // 4)
+        return result
 
     def _tool_annotate(self, args: dict) -> str:
         component_name = args.get("component_name", "").strip()

--- a/rtk_sf/mcp_server.py
+++ b/rtk_sf/mcp_server.py
@@ -27,8 +27,8 @@ Protocol:
     - Logs diagnostics to stderr (never stdout).
 
 Usage:
-    python -m rtk_sf serve [--project-root .]
-    claude mcp add rtk-sf -- python -m rtk_sf serve
+    python3 -m rtk_sf serve [--project-root .]
+    claude mcp add rtk-sf -- python3 -m rtk_sf serve
 """
 
 from __future__ import annotations

--- a/rtk_sf/nlp_compactor.py
+++ b/rtk_sf/nlp_compactor.py
@@ -66,19 +66,12 @@ _JA_FILLERS: list[str] = [
     r"よろしくお願いいたします[。！]?",
     r"よろしくお願い申し上げます[。！]?",
     r"お願いいたします[。！]?",
-    # Confirmation requests
-    r"確認してもらえますか[？。]?",
-    r"確認してください[。]?",
-    r"確認お願いします[。]?",
-    r"チェックしてください[。]?",
-    r"チェックしてもらえますか[？。]?",
-    r"見てもらえますか[？。]?",
-    r"見てください[。]?",
-    # Action request suffixes
+    # Polite action request suffixes — strip the suffix, preserve the verb before it
+    # e.g. "確認してください" → "確認"  (keep the intent verb, drop the polite wrapper)
     r"してください[。]?",
     r"して下さい[。]?",
-    r"してもらえますか[？]?",
-    r"していただけますか[？]?",
+    r"してもらえますか[？。]?",
+    r"していただけますか[？。]?",
     r"していただけると幸いです[。]?",
     r"してほしいです[。]?",
     r"してほしいのですが[。]?",

--- a/rtk_sf/nlp_compactor.py
+++ b/rtk_sf/nlp_compactor.py
@@ -1,0 +1,174 @@
+"""
+nlp_compactor.py — Bilingual (English + Japanese) prompt compactor.
+
+Strips conversational noise from user prompts before they consume tokens in
+the AI context window. Preserves Salesforce API names, method names, class
+names, and all structural parameters.
+
+Token impact: a 200-token polite request → ~80-token intent payload.
+"""
+
+from __future__ import annotations
+
+import re
+
+# ---------------------------------------------------------------------------
+# English filler patterns (case-insensitive)
+# ---------------------------------------------------------------------------
+
+_EN_FILLERS: list[str] = [
+    r"\bplease\b\s*",
+    r"\bcould\s+you\b\s*",
+    r"\bcan\s+you\b\s*",
+    r"\bwould\s+you\b\s*",
+    r"\bwould\s+you\s+mind\b\s*",
+    r"\bkindly\b\s*",
+    r"\bjust\b\s*",
+    r"\bquickly\b\s*",
+    r"\bsimply\b\s*",
+    r"\bbasically\b\s*",
+    r"\bactually\b\s*",
+    r"\bif\s+possible\b[,.]?\s*",
+    r"\bif\s+you\s+don'?t\s+mind\b[,.]?\s*",
+    r"\bfeel\s+free\s+to\b\s*",
+    r"\bgo\s+ahead\s+and\b\s*",
+    r"\blet\s+me\s+know\b[^.]*\.",
+    r"\bthanks?\b[.!]?\s*",
+    r"\bthank\s+you\b[.!]?\s*",
+    r"\bmuch\s+appreciated\b[.!]?\s*",
+    r"\bcheers\b[.!]?\s*",
+    r"\bhey\b[,]?\s*",
+    r"\bhi\b[,]?\s*",
+    r"\bhello\b[,]?\s*",
+    r"\bsorry\s+to\s+bother\s+you\b[,.]?\s*",
+    r"\bI\s+was\s+wondering\s+(if\s+)?(you\s+could\s+)?",
+    r"\bI\s+think\s+",
+    r"\bI\s+believe\s+",
+    r"\bI\s+need\s+you\s+to\s+",
+    r"\bI\s+want\s+you\s+to\s+",
+    r"\bI'?d\s+like\s+(you\s+to\s+)?",
+    r"\bmake\s+sure\s+to\s+",
+    r"\bdon'?t\s+forget\s+to\s+",
+]
+
+_EN_FILLER_RE = re.compile(
+    "|".join(_EN_FILLERS), re.IGNORECASE
+)
+
+# ---------------------------------------------------------------------------
+# Japanese filler/politeness patterns
+# ---------------------------------------------------------------------------
+
+_JA_FILLERS: list[str] = [
+    # Polite request endings
+    r"お願いします[。！]?",
+    r"よろしくお願いします[。！]?",
+    r"よろしくお願いいたします[。！]?",
+    r"よろしくお願い申し上げます[。！]?",
+    r"お願いいたします[。！]?",
+    # Confirmation requests
+    r"確認してもらえますか[？。]?",
+    r"確認してください[。]?",
+    r"確認お願いします[。]?",
+    r"チェックしてください[。]?",
+    r"チェックしてもらえますか[？。]?",
+    r"見てもらえますか[？。]?",
+    r"見てください[。]?",
+    # Action request suffixes
+    r"してください[。]?",
+    r"して下さい[。]?",
+    r"してもらえますか[？]?",
+    r"していただけますか[？]?",
+    r"していただけると幸いです[。]?",
+    r"してほしいです[。]?",
+    r"してほしいのですが[。]?",
+    # Softeners
+    r"ちょっと\s*",
+    r"少し\s*",
+    r"なるべく\s*",
+    r"できれば\s*",
+    r"可能であれば[、。]?\s*",
+    r"もし可能なら[、。]?\s*",
+    # Greetings / openers
+    r"すみません[、。]?\s*",
+    r"すいません[、。]?\s*",
+    r"失礼します[。]?\s*",
+    r"お世話になっています[。]?\s*",
+    r"お疲れ様です[。]?\s*",
+    # Closing phrases
+    r"以上です[。]?",
+    r"よろしくです[。]?",
+    r"引き続きよろしくお願いします[。]?",
+]
+
+_JA_FILLER_RE = re.compile("|".join(_JA_FILLERS))
+
+# Trailing Japanese grammatical particles (only when word-bounded)
+# Strips: を、に、は、が、で、も、と、の、へ、から — only at end of a word token
+_JA_PARTICLE_RE = re.compile(r"([^\s。、！？　]+)[をにはがでもとのへから](?=\s|$|[。、！？])")
+
+# ---------------------------------------------------------------------------
+# Salesforce API name protector
+# Matches: Account__c, Order__r, Ticket__e, AccountService.cls, etc.
+# These must NOT be stripped even if they match other patterns
+# ---------------------------------------------------------------------------
+
+_SF_API_RE = re.compile(
+    r"\b[A-Za-z][A-Za-z0-9_]*(__[cCrReEbBpP])\b"
+    r"|\b[A-Z][a-zA-Z0-9]+\.(cls|trigger|object|flow|xml|yaml)\b"
+    r"|\b(?:SELECT|FROM|WHERE|ORDER\s+BY|GROUP\s+BY|LIMIT|OFFSET|HAVING)\b",
+    re.IGNORECASE,
+)
+
+
+def compact_prompt(text: str) -> tuple[str, int, int]:
+    """
+    Strip conversational noise from a bilingual prompt.
+
+    Preserves Salesforce API names, method names, class names,
+    SOQL keywords, and any structural parameters.
+
+    Args:
+        text: Raw user prompt (English, Japanese, or mixed)
+
+    Returns:
+        (compacted_text, original_char_count, compacted_char_count)
+    """
+    original_len = len(text)
+    result = text
+
+    # Strip English fillers
+    result = _EN_FILLER_RE.sub("", result)
+
+    # Strip Japanese fillers
+    result = _JA_FILLER_RE.sub("", result)
+
+    # Strip trailing Japanese particles (but preserve the noun they follow)
+    result = _JA_PARTICLE_RE.sub(r"\1", result)
+
+    # Normalize whitespace
+    result = re.sub(r"[ \t]{2,}", " ", result)
+    result = re.sub(r"\n{3,}", "\n\n", result)
+    result = result.strip()
+
+    return result, original_len, len(result)
+
+
+def compact_prompt_report(text: str) -> str:
+    """
+    Return a formatted report of the compact_prompt result.
+    Estimates token savings (1 token ≈ 4 chars for English/Japanese mix).
+    """
+    compacted, orig_chars, new_chars = compact_prompt(text)
+    removed = orig_chars - new_chars
+    est_tokens_saved = max(0, removed // 4)
+    pct = round(removed / orig_chars * 100) if orig_chars else 0
+
+    lines = [
+        f"── Compacted prompt ({pct}% shorter, ~{est_tokens_saved} tokens saved) ──",
+        "",
+        compacted,
+        "",
+        f"[Original: {orig_chars} chars → Compacted: {new_chars} chars]",
+    ]
+    return "\n".join(lines)

--- a/rtk_sf/ui_generator.py
+++ b/rtk_sf/ui_generator.py
@@ -7,7 +7,7 @@ that visualizes the Salesforce component graph with interactive node selection,
 path highlighting, and a YAML spec sidebar.
 
 Usage:
-    python -m rtk_sf ui [--project-root .] [--output dist/architecture_map.html]
+    python3 -m rtk_sf ui [--project-root .] [--output dist/architecture_map.html]
 """
 
 from __future__ import annotations

--- a/rtk_sf/vision_ocr.py
+++ b/rtk_sf/vision_ocr.py
@@ -1,0 +1,148 @@
+"""
+vision_ocr.py — Local bilingual OCR interceptor (EN + JA).
+
+Extracts text from image files locally using open-source OCR engines,
+bypassing Claude's multimodal vision token pricing entirely.
+
+Primary engine:  PaddleOCR  (pip install paddleocr)
+Fallback engine: EasyOCR    (pip install easyocr)
+
+Token impact: a typical screenshot costs 800–8,000 vision tokens when passed
+as an image. This module returns the extracted text (~50–300 tokens) instead.
+
+Install:
+    pip install paddleocr          # recommended — EN+JA, lightweight CRNN
+    pip install easyocr            # fallback — PyTorch sequence pipeline
+    pip install Pillow             # optional — grayscale preprocessing
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+_SUPPORTED_EXT = {".png", ".jpg", ".jpeg", ".bmp", ".tiff", ".tif", ".webp"}
+_MIN_CONFIDENCE = 0.45
+
+
+# ---------------------------------------------------------------------------
+# Optional preprocessing — grayscale + contrast boost for noisy images
+# ---------------------------------------------------------------------------
+
+def _preprocess(image_path: str) -> str:
+    """
+    Convert to grayscale and sharpen contrast. Returns path to a temp file.
+    Falls back to original path if Pillow is not installed.
+    """
+    try:
+        from PIL import Image, ImageEnhance, ImageFilter
+        import tempfile
+
+        img = Image.open(image_path).convert("L")
+        img = ImageEnhance.Contrast(img).enhance(2.0)
+        img = img.filter(ImageFilter.SHARPEN)
+        suffix = Path(image_path).suffix or ".png"
+        tmp = tempfile.NamedTemporaryFile(delete=False, suffix=suffix)
+        img.save(tmp.name)
+        return tmp.name
+    except ImportError:
+        return image_path
+    except Exception:
+        return image_path
+
+
+# ---------------------------------------------------------------------------
+# OCR engines
+# ---------------------------------------------------------------------------
+
+def _paddle_extract(image_path: str) -> list[str]:
+    from paddleocr import PaddleOCR
+    # 'japan' lang pack covers Kanji/Kana + alphanumeric English
+    ocr = PaddleOCR(use_angle_cls=True, lang="japan", show_log=False)
+    result = ocr.ocr(image_path, cls=True)
+    if not result or not result[0]:
+        return []
+    lines = []
+    for line in result[0]:
+        text, confidence = line[1]
+        if confidence > _MIN_CONFIDENCE:
+            lines.append(text)
+    return lines
+
+
+def _easyocr_extract(image_path: str) -> list[str]:
+    import easyocr
+    reader = easyocr.Reader(["en", "ja"], gpu=False, verbose=False)
+    result = reader.readtext(image_path)
+    return [text for (_, text, conf) in result if conf > _MIN_CONFIDENCE]
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def extract_image_text(image_path: str, preprocess: bool = True) -> str:
+    """
+    Extract English and Japanese text from an image file using local OCR.
+
+    Tries PaddleOCR first, falls back to EasyOCR if not installed.
+    Optionally applies grayscale + contrast enhancement before OCR.
+
+    Args:
+        image_path:  Path to image file (.png .jpg .jpeg .bmp .tiff .webp)
+        preprocess:  Apply grayscale/contrast boost (default True)
+
+    Returns:
+        Formatted Markdown text block ready to inject into Claude context,
+        or an error/install-hint string if OCR cannot run.
+    """
+    path = Path(image_path)
+
+    if not path.exists():
+        return f"[rtk-sf OCR Error: File not found: {image_path}]"
+
+    if path.suffix.lower() not in _SUPPORTED_EXT:
+        supported = ", ".join(sorted(_SUPPORTED_EXT))
+        return (
+            f"[rtk-sf OCR Error: Unsupported format '{path.suffix}'. "
+            f"Supported: {supported}]"
+        )
+
+    work_path = _preprocess(image_path) if preprocess else image_path
+    engine = "unknown"
+    lines: list[str] = []
+
+    try:
+        lines = _paddle_extract(work_path)
+        engine = "PaddleOCR"
+    except ImportError:
+        try:
+            lines = _easyocr_extract(work_path)
+            engine = "EasyOCR"
+        except ImportError:
+            return (
+                "[rtk-sf OCR: No OCR engine installed.]\n"
+                "Install one of:\n"
+                "  pip install paddleocr   ← recommended (EN + JA)\n"
+                "  pip install easyocr     ← alternative fallback\n"
+            )
+    except Exception as exc:
+        return f"[rtk-sf OCR Error ({engine}): {exc}]"
+    finally:
+        if work_path != image_path and Path(work_path).exists():
+            try:
+                os.unlink(work_path)
+            except OSError:
+                pass
+
+    if not lines:
+        return f"[rtk-sf OCR ({engine}): No text detected in {path.name}]"
+
+    return (
+        "```text\n"
+        f"[rtk-sf: Local OCR Context — {engine}]\n"
+        f"Source: {path.name} | Lines extracted: {len(lines)}\n"
+        f"{'─' * 50}\n"
+        + "\n".join(lines)
+        + "\n```"
+    )

--- a/rtk_sf/watcher.py
+++ b/rtk_sf/watcher.py
@@ -5,7 +5,7 @@ Uses the `watchdog` library to monitor a Salesforce DX project directory.
 When a .cls or .xml file changes, it is re-indexed immediately.
 
 Usage:
-    python -m rtk_sf watch [--path ./force-app]
+    python3 -m rtk_sf watch [--path ./force-app]
 """
 
 from __future__ import annotations

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -121,12 +121,12 @@ check_python() {
 install_rtk_sf() {
   info "Installing rtk-sf[all] from GitHub..."
 
-  if "$PYTHON_CMD" -m pip install --quiet "git+${RTK_REPO}@main#egg=rtk-sf[all]" 2>&1; then
+  if "$PYTHON_CMD" -m pip install --quiet "rtk-sf[all] @ git+${RTK_REPO}@main" 2>&1; then
     RTK_VERSION=$("$PYTHON_CMD" -m rtk_sf --version 2>/dev/null || echo "unknown")
     success "rtk-sf $RTK_VERSION installed (core + vector re-ranking + OCR)."
   else
     error "pip install failed."
-    error "Try manually: pip install \"git+${RTK_REPO}@main#egg=rtk-sf[all]\""
+    error "Try manually: pip install \"rtk-sf[all] @ git+${RTK_REPO}@main\""
     exit 1
   fi
 }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -34,29 +34,85 @@ RTK_REPO="https://github.com/furuCRM-Inc/rtk-sf.git"
 # ---------------------------------------------------------------------------
 # Step 1: Check Python version
 # ---------------------------------------------------------------------------
+
+# Run a Python command with a 5-second timeout.
+# Usage: _py_timeout <python_cmd> <args...>
+_py_timeout() {
+  local cmd="$1"; shift
+  if command -v timeout &>/dev/null; then
+    timeout 5 "$cmd" "$@"
+  else
+    # Fallback: background process + manual kill
+    "$cmd" "$@" &
+    local pid=$!
+    local i=0
+    while kill -0 "$pid" 2>/dev/null && [ $i -lt 5 ]; do
+      sleep 1; i=$((i+1))
+    done
+    if kill -0 "$pid" 2>/dev/null; then
+      kill "$pid" 2>/dev/null
+      return 1
+    fi
+    wait "$pid"
+  fi
+}
+
+# Detect Microsoft Store Python stub (Windows/Git Bash).
+# The stub silently opens the Store instead of running Python — causes hangs.
+_check_ms_store_stub() {
+  local py_path
+  py_path=$(command -v "$1" 2>/dev/null || true)
+  if echo "$py_path" | grep -qi "WindowsApps"; then
+    echo ""
+    error "'$1' points to a Microsoft Store stub, not a real Python installation."
+    error "  Detected path: $py_path"
+    echo ""
+    echo "  Fix (2 steps):"
+    echo "  1. Windows Settings → Apps → Advanced app settings → App execution aliases"
+    echo "     → turn OFF 'python.exe' and 'python3.exe'"
+    echo "  2. Install real Python from https://python.org/downloads"
+    echo "     (check 'Add Python to PATH' during setup)"
+    echo ""
+    exit 1
+  fi
+}
+
 check_python() {
   info "Checking Python version..."
 
   if command -v python3 &>/dev/null; then
+    _check_ms_store_stub python3
     PYTHON_CMD="python3"
   elif command -v python &>/dev/null; then
+    _check_ms_store_stub python
     PYTHON_CMD="python"
   else
-    error "Python not found. Please install Python 3.9+ from https://python.org"
+    error "Python not found. Install Python 3.9+ from https://python.org/downloads"
+    if echo "$OSTYPE" | grep -qi "msys\|cygwin\|win"; then
+      error "(Windows: check 'Add Python to PATH' during installation)"
+    fi
     exit 1
   fi
 
-  PYTHON_VERSION=$("$PYTHON_CMD" -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")
-  PYTHON_MAJOR=$("$PYTHON_CMD" -c "import sys; print(sys.version_info.major)")
-  PYTHON_MINOR=$("$PYTHON_CMD" -c "import sys; print(sys.version_info.minor)")
+  # Run with timeout — a Store stub or broken install can hang indefinitely
+  PYTHON_VERSION=$(_py_timeout "$PYTHON_CMD" -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')" 2>/dev/null) || {
+    error "'$PYTHON_CMD' timed out or failed to run."
+    error "This usually means it is a Microsoft Store stub or a broken install."
+    error "Fix: https://python.org/downloads (check 'Add Python to PATH')"
+    error "     Then disable python.exe in Windows Settings > App execution aliases."
+    exit 1
+  }
+
+  PYTHON_MAJOR="${PYTHON_VERSION%%.*}"
+  PYTHON_MINOR="${PYTHON_VERSION##*.}"
 
   if [ "$PYTHON_MAJOR" -lt 3 ] || { [ "$PYTHON_MAJOR" -eq 3 ] && [ "$PYTHON_MINOR" -lt 9 ]; }; then
     error "Python 3.9+ required. Found: $PYTHON_VERSION"
-    error "Please upgrade Python: https://python.org/downloads"
+    error "Upgrade: https://python.org/downloads"
     exit 1
   fi
 
-  success "Python $PYTHON_VERSION found."
+  success "Python $PYTHON_VERSION found at: $(command -v "$PYTHON_CMD")"
 }
 
 # ---------------------------------------------------------------------------

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -10,7 +10,7 @@
 # What this does:
 #   1. Checks Python 3.9+
 #   2. pip install rtk-sf[all]  (core + vector re-ranking + OCR)
-#   3. python -m rtk_sf install (index + patch CLAUDE.md + print next steps)
+#   3. python3 -m rtk_sf install (index + patch CLAUDE.md + print next steps)
 #
 # Requirements:
 #   - Python 3.9+ with pip

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -9,35 +9,27 @@
 #
 # What this does:
 #   1. Checks Python 3.9+
-#   2. Installs rtk-sf via pip
-#   3. Indexes the current directory (Salesforce DX project)
-#   4. Prints MCP setup instructions
+#   2. pip install rtk-sf[all]  (core + vector re-ranking + OCR)
+#   3. python -m rtk_sf install (index + patch CLAUDE.md + print next steps)
 #
 # Requirements:
 #   - Python 3.9+ with pip
 #   - Salesforce DX project (force-app/ directory or similar)
-#   - curl (for remote install only)
 
 set -euo pipefail
 
-# ---------------------------------------------------------------------------
-# Colors
-# ---------------------------------------------------------------------------
 RED='\033[0;31m'
 GREEN='\033[0;32m'
 BLUE='\033[0;34m'
-YELLOW='\033[1;33m'
 BOLD='\033[1m'
-NC='\033[0m' # No Color
+NC='\033[0m'
 
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
 info()    { echo -e "${BLUE}[rtk-sf]${NC} $*"; }
 success() { echo -e "${GREEN}[rtk-sf]${NC} $*"; }
-warn()    { echo -e "${YELLOW}[rtk-sf]${NC} $*"; }
 error()   { echo -e "${RED}[rtk-sf] ERROR:${NC} $*" >&2; }
 bold()    { echo -e "${BOLD}$*${NC}"; }
+
+RTK_REPO="https://github.com/furuCRM-Inc/rtk-sf.git"
 
 # ---------------------------------------------------------------------------
 # Step 1: Check Python version
@@ -68,167 +60,26 @@ check_python() {
 }
 
 # ---------------------------------------------------------------------------
-# Step 2: Install rtk-sf
+# Step 2: pip install rtk-sf[all]
 # ---------------------------------------------------------------------------
-RTK_REPO="https://github.com/furuCRM-Inc/rtk-sf.git"
-
 install_rtk_sf() {
-  info "Installing rtk-sf from GitHub..."
+  info "Installing rtk-sf[all] from GitHub..."
 
   if "$PYTHON_CMD" -m pip install --quiet "git+${RTK_REPO}@main#egg=rtk-sf[all]" 2>&1; then
-    success "rtk-sf installed successfully (all extras: vector re-ranking + OCR)."
+    RTK_VERSION=$("$PYTHON_CMD" -m rtk_sf --version 2>/dev/null || echo "unknown")
+    success "rtk-sf $RTK_VERSION installed (core + vector re-ranking + OCR)."
   else
     error "pip install failed."
     error "Try manually: pip install \"git+${RTK_REPO}@main#egg=rtk-sf[all]\""
     exit 1
   fi
-
-  # Verify installation
-  RTK_VERSION=$("$PYTHON_CMD" -m rtk_sf --version 2>/dev/null || echo "unknown")
-  success "rtk-sf $RTK_VERSION ready."
 }
 
 # ---------------------------------------------------------------------------
-# Step 3: Detect Salesforce project
+# Step 3: Delegate everything else to the Python CLI
 # ---------------------------------------------------------------------------
-detect_project() {
-  info "Detecting Salesforce DX project..."
-
-  if [ -d "force-app" ]; then
-    success "force-app/ directory found."
-    SF_SOURCE_DIR="force-app"
-  elif [ -d "src" ] && find src -name "*.cls" -maxdepth 5 | grep -q .; then
-    warn "No force-app/ directory; using src/ (non-standard layout)."
-    SF_SOURCE_DIR="src"
-  elif find . -name "*.cls" -maxdepth 8 | grep -q .; then
-    warn "No force-app/ directory; scanning project root."
-    SF_SOURCE_DIR="."
-  else
-    warn "No Apex (.cls) files found in the current directory."
-    warn "Make sure you're running this from your Salesforce DX project root."
-    SF_SOURCE_DIR="force-app"
-  fi
-}
-
-# ---------------------------------------------------------------------------
-# Step 4: Run initial index
-# ---------------------------------------------------------------------------
-run_index() {
-  info "Indexing Salesforce metadata in ${SF_SOURCE_DIR}/..."
-  echo ""
-
-  if "$PYTHON_CMD" -m rtk_sf index --path "./$SF_SOURCE_DIR"; then
-    echo ""
-    success "Index complete. Specs stored in .rtk-sf/"
-  else
-    warn "Indexing encountered errors. Check the output above."
-    warn "You can re-run: rtk-sf index"
-  fi
-}
-
-# ---------------------------------------------------------------------------
-# Step 5: Patch CLAUDE.md so Claude Code uses rtk-sf tools automatically
-# ---------------------------------------------------------------------------
-RTK_CLAUDE_MARKER="## Code Search"
-RTK_CLAUDE_MARKER_V4="get_class_skeleton"
-
-patch_claude_md() {
-  local claude_md="CLAUDE.md"
-
-  # Skip if already patched with v0.4+ tool list
-  if [ -f "$claude_md" ] && grep -q "$RTK_CLAUDE_MARKER_V4" "$claude_md" 2>/dev/null; then
-    success "CLAUDE.md already has rtk-sf v0.4 instructions. Skipping."
-    return
-  fi
-
-  # If older v0.3 block exists, strip it before inserting new one
-  if [ -f "$claude_md" ] && grep -q "$RTK_CLAUDE_MARKER" "$claude_md" 2>/dev/null; then
-    warn "Upgrading CLAUDE.md from rtk-sf v0.3 to v0.4 tool list..."
-    local tmp
-    tmp=$(mktemp)
-    awk '/## Code Search/{found=1} found && /^## / && !/## Code Search/{found=0} !found' "$claude_md" > "$tmp"
-    mv "$tmp" "$claude_md"
-  fi
-
-  # Build block using string concatenation — no heredoc (incompatible with curl|bash)
-  local NL T BT block
-  NL='
-'
-  T='|'
-  BT='`'
-
-  block="${NL}## Code Search & Data — Use rtk-sf First (Required)${NL}"
-  block="${block}${NL}This project is indexed by **rtk-sf**. Always use the MCP tools before reading raw files or calling sf CLI:${NL}"
-  block="${block}${NL}${T} Task ${T} Tool to call ${T}"
-  block="${block}${NL}${T}---|---${T}"
-  block="${block}${NL}${T} Find a component by name or keyword ${T} ${BT}search_codebase(query)${BT} ${T}"
-  block="${block}${NL}${T} Read a component spec / fields / methods ${T} ${BT}query_compressed_spec(component_name)${BT} ${T}"
-  block="${block}${NL}${T} Blast-radius before editing ${T} ${BT}get_relations(component_name)${BT} ${T}"
-  block="${block}${NL}${T} List all Apex classes / objects / flows ${T} ${BT}list_components(type)${BT} ${T}"
-  block="${block}${NL}${T} Write discovered business logic back ${T} ${BT}annotate_component(component_name, key, value)${BT} ${T}"
-  block="${block}${NL}${T} Read an Apex class before editing (surgical) ${T} ${BT}get_class_skeleton(component_name, focus_methods)${BT} ${T}"
-  block="${block}${NL}${T} Deploy / retrieve / run tests silently ${T} ${BT}sf_command(action, target_org, ...)${BT} ${T}"
-  block="${block}${NL}${T} Get object field list for data creation ${T} ${BT}get_object_schema(object_name)${BT} ${T}"
-  block="${block}${NL}${T} Inspect existing records (sample only) ${T} ${BT}soql_query(query, target_org, sample_size)${BT} ${T}"
-  block="${block}${NL}${NL}**Never** do these directly — use the tool instead:"
-  block="${block}${NL}- Read a raw .cls file       -> use ${BT}get_class_skeleton${BT}"
-  block="${block}${NL}- sf sobject describe         -> use ${BT}get_object_schema${BT}"
-  block="${block}${NL}- sf data query               -> use ${BT}soql_query${BT}"
-  block="${block}${NL}- sf project deploy start     -> use ${BT}sf_command(action=\"deploy\")${BT}"
-  block="${block}${NL}${NL}If search returns no results, re-index with: ${BT}python3 -m rtk_sf index${BT}"
-  block="${block}${NL}Do NOT use ${BT}npx rtk-sf${BT} — rtk-sf is a Python package, not npm.${NL}"
-
-  if [ -f "$claude_md" ]; then
-    local first_line rest
-    first_line=$(head -1 "$claude_md")
-    rest=$(tail -n +2 "$claude_md")
-    printf '%s\n%s\n%s\n' "$first_line" "$block" "$rest" > "$claude_md"
-    success "CLAUDE.md updated with rtk-sf tool instructions."
-  else
-    printf '# Salesforce Project\n%s\n' "$block" > "$claude_md"
-    success "CLAUDE.md created with rtk-sf tool instructions."
-  fi
-}
-
-# ---------------------------------------------------------------------------
-# Step 6: Print next steps
-# ---------------------------------------------------------------------------
-print_next_steps() {
-  echo ""
-  bold "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-  bold "  rtk-sf is ready!"
-  bold "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-  echo ""
-  info "Next steps:"
-  echo ""
-  echo "  1. Register with Claude Code:"
-  echo -e "     ${BOLD}claude mcp add rtk-sf -- $PYTHON_CMD -m rtk_sf serve${NC}"
-  echo ""
-  echo "  2. Generate the visual architecture map:"
-  echo -e "     ${BOLD}$PYTHON_CMD -m rtk_sf ui${NC}"
-  echo -e "     ${BOLD}open dist/architecture_map.html${NC}"
-  echo ""
-  echo "  3. Enable live file watching during development:"
-  echo -e "     ${BOLD}$PYTHON_CMD -m rtk_sf watch${NC}"
-  echo ""
-  echo "  4. Re-index after adding new Apex classes or objects:"
-  echo -e "     ${BOLD}$PYTHON_CMD -m rtk_sf index${NC}"
-  echo ""
-  # Detect if the rtk-sf CLI is in PATH; if not, show how to add it
-  if ! command -v rtk-sf &>/dev/null; then
-    local script_dir
-    script_dir=$("$PYTHON_CMD" -c "import sysconfig; print(sysconfig.get_path('scripts'))" 2>/dev/null || echo "")
-    if [ -n "$script_dir" ]; then
-      warn "Note: 'rtk-sf' CLI not in PATH. Add it with:"
-      echo -e "     ${BOLD}export PATH=\"\$PATH:$script_dir\"${NC}"
-      echo "     (Add this line to your ~/.zshrc or ~/.bashrc to make it permanent)"
-      echo ""
-    fi
-  fi
-  info "Docs: https://github.com/furuCRM-Inc/rtk-sf"
-  echo ""
-  echo -e "Built with love by ${BOLD}furuCRM Inc.${NC} — https://www.furucrm.com"
-  echo ""
+run_setup() {
+  "$PYTHON_CMD" -m rtk_sf install
 }
 
 # ---------------------------------------------------------------------------
@@ -242,10 +93,7 @@ main() {
 
   check_python
   install_rtk_sf
-  detect_project
-  run_index
-  patch_claude_md
-  print_next_steps
+  run_setup
 }
 
 main "$@"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -75,11 +75,11 @@ RTK_REPO="https://github.com/furuCRM-Inc/rtk-sf.git"
 install_rtk_sf() {
   info "Installing rtk-sf from GitHub..."
 
-  if "$PYTHON_CMD" -m pip install --quiet "git+${RTK_REPO}@main" 2>&1; then
-    success "rtk-sf installed successfully."
+  if "$PYTHON_CMD" -m pip install --quiet "git+${RTK_REPO}@main#egg=rtk-sf[all]" 2>&1; then
+    success "rtk-sf installed successfully (all extras: vector re-ranking + OCR)."
   else
     error "pip install failed."
-    error "Try manually: pip install git+${RTK_REPO}@main"
+    error "Try manually: pip install \"git+${RTK_REPO}@main#egg=rtk-sf[all]\""
     exit 1
   fi
 


### PR DESCRIPTION
## Summary

- **`compact_prompt`** — Bilingual (EN + JA) prompt compactor. Strips polite fillers, pleasantries, and grammatical particles while preserving Salesforce API names and intent verbs. 200-token polite request → ~80-token intent payload.
- **`validate_apex`** — Local Apex dry-run: catches SOQL/DML in loops, unbalanced braces, System.debug, TODO comments, `@future` parameter violations. Zero org call.
- **`validate_soql`** — Local SOQL dry-run: catches SELECT *, LIMIT > 50k, missing WHERE+LIMIT, unbalanced parentheses. Zero org call.
- **`get_roi_stats`** — Visual terminal counter of tokens and dollars saved this session. Auto-recorded by `query_compressed_spec`, `get_class_skeleton`, `get_object_schema`, `soql_query`.
- **`extract_image_text`** — Local OCR interceptor (PaddleOCR primary, EasyOCR fallback). Extracts EN+JA text from screenshots/mockups locally, bypassing Claude's multimodal vision token cost. Includes optional grayscale preprocessing.
- **`python3 -m rtk_sf install`** — New CLI subcommand that does full setup: detect SF source, index, patch CLAUDE.md (14-tool table), print next steps. `install.sh` now delegates to this after pip.
- **Windows MS Store stub fix** — Detects if `python`/`python3` resolves to a WindowsApps stub, exits immediately with a 2-step fix. Adds 5-second timeout so broken installs fail loudly instead of hanging.
- **`pip install rtk-sf[all]`** — Single command bundles core + vector re-ranking (numpy) + OCR (paddleocr + Pillow).
- All commands standardised to `python3`.

## New files

| File | Purpose |
|---|---|
| `rtk_sf/nlp_compactor.py` | Bilingual prompt compactor |
| `rtk_sf/dry_run.py` | Apex/SOQL dry-run + ROI session tracker |
| `rtk_sf/vision_ocr.py` | Local OCR interceptor (PaddleOCR / EasyOCR) |

## Total MCP tools: 14 (was 9)

| New tool | Token impact |
|---|---|
| `compact_prompt` | ~60% prompt size reduction |
| `validate_apex` | Catch bugs before sandbox deploy |
| `validate_soql` | Catch errors before org call |
| `get_roi_stats` | Visualise cumulative savings |
| `extract_image_text` | ~1,500 vision tokens → ~150 text tokens |

## Test plan

- [x] All 14 tools imported and dispatched correctly
- [x] `compact_prompt`: EN fillers stripped, JA intent verb preserved, SF API names untouched
- [x] `validate_apex`: SOQL+DML in loop → 2 errors; valid code → clean
- [x] `validate_soql`: SELECT * / LIMIT > 50k / no WHERE → correct errors/warnings
- [x] `get_roi_stats`: savings accumulate correctly across tool calls
- [x] `extract_image_text`: missing file / unsupported ext / no engine → clear error messages
- [x] `python3 -m rtk_sf install`: full flow on a fake SF project → exit 0, CLAUDE.md created
- [x] `install.sh`: syntax clean via `bash -n`, MS Store stub detection pattern verified
- [x] All user-facing commands use `python3`, not `python`
- [x] `shutil` import present (NameError crash fixed)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)