### PR TITLE
fix: single-line upgrade command (zsh paste indent bug)

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,10 +152,13 @@ Your AI agent now has instant, token-efficient access to your entire Salesforce 
 Run this inside your Salesforce project directory:
 
 ```bash
+python3 -m pip install --upgrade pip && \
 python3 -m pip install --force-reinstall --no-cache-dir \
   "rtk-sf[all] @ git+https://github.com/furuCRM-Inc/rtk-sf.git@main" \
   && python3 -m rtk_sf install
 ```
+
+> **Requires pip ≥ 22.** The first line upgrades pip if needed — safe to run even if already up to date.
 
 This reinstalls the latest version and automatically upgrades your `CLAUDE.md` to the current tool list.
 
@@ -163,6 +166,7 @@ This reinstalls the latest version and automatically upgrades your `CLAUDE.md` t
 
 | Step | What happens |
 |---|---|
+| `pip install --upgrade pip` | Ensures pip ≥ 22 (required for PEP 508 VCS syntax) |
 | `pip install --force-reinstall` | Replaces the installed package with the latest |
 | `python3 -m rtk_sf install` | Re-indexes any new/changed files |
 | | Upgrades `CLAUDE.md` (v0.3 → v0.5 or v0.4 → v0.5) |

--- a/README.md
+++ b/README.md
@@ -152,10 +152,7 @@ Your AI agent now has instant, token-efficient access to your entire Salesforce 
 Run this inside your Salesforce project directory:
 
 ```bash
-python3 -m pip install --upgrade pip && \
-python3 -m pip install --force-reinstall --no-cache-dir \
-  "rtk-sf[all] @ git+https://github.com/furuCRM-Inc/rtk-sf.git@main" \
-  && python3 -m rtk_sf install
+python3 -m pip install --upgrade pip && python3 -m pip install --force-reinstall --no-cache-dir "rtk-sf[all] @ git+https://github.com/furuCRM-Inc/rtk-sf.git@main" && python3 -m rtk_sf install
 ```
 
 > **Requires pip ≥ 22.** The first line upgrades pip if needed — safe to run even if already up to date.

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -116,7 +116,23 @@ check_python() {
 }
 
 # ---------------------------------------------------------------------------
-# Step 2: pip install rtk-sf[all]
+# Step 2: Ensure pip >= 22 (required for PEP 508 "name @ git+url" syntax)
+# ---------------------------------------------------------------------------
+upgrade_pip() {
+  PIP_VERSION=$("$PYTHON_CMD" -m pip --version 2>/dev/null | awk '{print $2}')
+  PIP_MAJOR="${PIP_VERSION%%.*}"
+  if [ -z "$PIP_MAJOR" ] || [ "$PIP_MAJOR" -lt 22 ]; then
+    info "pip $PIP_VERSION is too old (need 22+). Upgrading pip..."
+    "$PYTHON_CMD" -m pip install --quiet --upgrade pip || {
+      error "Failed to upgrade pip. Try: $PYTHON_CMD -m pip install --upgrade pip"
+      exit 1
+    }
+    success "pip upgraded."
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Step 3: pip install rtk-sf[all]
 # ---------------------------------------------------------------------------
 install_rtk_sf() {
   info "Installing rtk-sf[all] from GitHub..."
@@ -148,6 +164,7 @@ main() {
   echo ""
 
   check_python
+  upgrade_pip
   install_rtk_sf
   run_setup
 }


### PR DESCRIPTION
## Summary

- Multi-line `\\` continuation with leading spaces caused zsh to read `  python3` (with spaces) as the command name → `zsh: command not found:   python3`
- Collapsed upgrade command to a single line — safe to copy-paste in any shell

## Verified

Ran full end-to-end on macOS/zsh:
- pip upgraded ✅
- `rtk-sf[all]` installed from main ✅
- `python3 -m rtk_sf install` → 751 skipped, 0 errors ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)