### PR TITLE
fix(deps): lower numpy to >=1.26.0 for Python 3.9 compat

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,10 +38,10 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-vector = ["numpy>=2.5.2"]
+vector = ["numpy>=1.26.0"]
 ocr = ["paddleocr", "Pillow"]
 ocr-fallback = ["easyocr", "Pillow"]
-all = ["numpy>=2.5.2", "paddleocr", "Pillow"]
+all = ["numpy>=1.26.0", "paddleocr", "Pillow"]
 dev = [
     "pytest>=9.1.1",
     "pytest-cov>=7.1.0",


### PR DESCRIPTION
## Summary

- `numpy>=2.5.2` requires Python 3.10+, causing install failure on Python 3.9 (`No matching distribution found`)
- Lowered to `numpy>=1.26.0` — resolves to `2.0.2` on Python 3.9, latest (`2.5.3`) on Python 3.10+
- Applies to both `[vector]` and `[all]` extras in `pyproject.toml`

## Test plan

- [ ] `pip install "rtk-sf[all] @ git+..."` succeeds on Python 3.9
- [ ] `pip install "rtk-sf[all] @ git+..."` still resolves numpy 2.x on Python 3.10+

🤖 Generated with [Claude Code](https://claude.com/claude-code)