### PR TITLE
feat(hooks): auto-wire OCR intercept + prompt compactor hooks

### DIFF
--- a/rtk_sf/__main__.py
+++ b/rtk_sf/__main__.py
@@ -23,8 +23,9 @@ import sys
 from pathlib import Path
 
 # CLAUDE.md markers used by install and upgrade detection
-_MARKER_V5 = "get_roi_stats"        # v0.5-only tool — confirms full 14-tool block
-_MARKER_V4 = "get_class_skeleton"   # v0.4 tool — present but missing 5 new v0.5 tools
+_MARKER_V5_1 = "Image / screenshot rule"  # v0.5.1 — inline image guidance added
+_MARKER_V5 = "get_roi_stats"              # v0.5 — 14-tool block, missing image rule
+_MARKER_V4 = "get_class_skeleton"         # v0.4 — 9-tool block
 _MARKER_BASE = "## Code Search"
 
 
@@ -55,16 +56,19 @@ def _detect_sf_source(project_root: Path) -> Path | None:
 def _patch_claude_md(project_root: Path) -> None:
     claude_md = project_root / "CLAUDE.md"
 
-    if claude_md.exists() and _MARKER_V5 in claude_md.read_text(encoding="utf-8"):
-        _success("CLAUDE.md already has rtk-sf v0.5 instructions. Skipping.")
+    if claude_md.exists() and _MARKER_V5_1 in claude_md.read_text(encoding="utf-8"):
+        _success("CLAUDE.md already has rtk-sf v0.5.1 instructions. Skipping.")
         return
 
-    # Strip old block (v0.3 or v0.4) if present, then rewrite with full v0.5 tool list
+    # Strip old block (v0.3 / v0.4 / v0.5) and rewrite with latest tool list
     if claude_md.exists() and _MARKER_BASE in claude_md.read_text(encoding="utf-8"):
-        if _MARKER_V4 in claude_md.read_text(encoding="utf-8"):
-            _warn("Upgrading CLAUDE.md from v0.4 to v0.5 tool list (5 new tools)...")
+        text = claude_md.read_text(encoding="utf-8")
+        if _MARKER_V5 in text and _MARKER_V4 in text:
+            _warn("Upgrading CLAUDE.md from v0.5 to v0.5.1 (inline image guidance)...")
+        elif _MARKER_V4 in text:
+            _warn("Upgrading CLAUDE.md from v0.4 to v0.5.1 (5 new tools + image rule)...")
         else:
-            _warn("Upgrading CLAUDE.md from v0.3 to v0.5 tool list...")
+            _warn("Upgrading CLAUDE.md from v0.3 to v0.5.1...")
         lines = claude_md.read_text(encoding="utf-8").splitlines()
         in_block = False
         kept: list[str] = []

--- a/rtk_sf/__main__.py
+++ b/rtk_sf/__main__.py
@@ -104,6 +104,11 @@ This project is indexed by **rtk-sf**. Always use the MCP tools before reading r
 - sf sobject describe        → `get_object_schema`
 - sf data query              → `soql_query`
 - sf project deploy start    → `sf_command(action="deploy")`
+- Read an inline pasted image with native vision → ask for the file path, then `extract_image_text(path)`
+
+**Image / screenshot rule:** `extract_image_text` requires a file path on disk.
+If the user pastes an image inline without a path, reply:
+"To save vision tokens, please share the file path (e.g. `~/Downloads/screenshot.png`) so I can run local OCR instead."
 
 If search returns no results, re-index with: `python3 -m rtk_sf index`
 Do NOT use `npx rtk-sf` — rtk-sf is a Python package, not npm.

--- a/rtk_sf/mcp_server.py
+++ b/rtk_sf/mcp_server.py
@@ -326,14 +326,18 @@ _TOOLS: list[dict[str, Any]] = [
             "Supports: .png .jpg .jpeg .bmp .tiff .webp. "
             "Token impact: a 1280×800 screenshot costs ~1,600 vision tokens as an image; "
             "this returns the extracted text at ~100–300 tokens instead. "
-            "Use this when the user attaches a screenshot, mockup, error dialog, or form image."
+            "IMPORTANT: requires a file path on disk. "
+            "When the user pastes an image inline (no path given), ask them: "
+            "'To avoid vision token cost, please share the file path (e.g. ~/Downloads/screenshot.png) "
+            "so I can run local OCR instead.' "
+            "Do NOT read inline images with native vision when a path can be obtained."
         ),
         "inputSchema": {
             "type": "object",
             "properties": {
                 "image_path": {
                     "type": "string",
-                    "description": "Absolute or relative path to the image file.",
+                    "description": "Absolute or relative path to the image file on disk. Not for inline/pasted images.",
                 },
                 "preprocess": {
                     "type": "boolean",


### PR DESCRIPTION
## Problem

Two passive MCP tools (`extract_image_text`, `compact_prompt`) were never being called because Claude uses native vision for inline images and sends prompts as-is — both bypass MCP tools entirely.

## Solution: Claude Code hooks

Two hook scripts wired automatically into `.claude/settings.json` during `python3 -m rtk_sf install`:

### `PreToolUse[Read]` → `ocr_intercept.py`
- Intercepts any `Read` call on an image file (`.png .jpg .jpeg .bmp .tiff .webp`)
- Runs local PaddleOCR/EasyOCR instead — saves ~1,500 vision tokens
- Exits 2 so Claude receives the OCR text as the result (not the raw image)
- Fail-open: exits 0 if OCR engine not installed

### `UserPromptSubmit` → `compact_prompt.py`
- Auto-compacts long bilingual (EN+JA) prompts before they are sent
- Thresholds: JA ≥ 50 chars, EN ≥ 300 chars, ≥ 5% reduction
- Outputs `{"prompt": compacted}` — Claude Code replaces the prompt transparently
- Fail-open: exits 0 on any error

### `_patch_claude_settings()` in `__main__.py`
- Merges hooks into existing `.claude/settings.json` without overwriting other config
- Idempotent: skips if hooks already present

## Verified

- Fresh install: CLAUDE.md + settings.json created ✅
- Existing settings.json: merged, original hooks preserved ✅  
- Idempotent re-run: skips correctly ✅
- OCR hook exit 0 for non-images, exit 2 for images ✅
- Compact hook: JA 70 chars → 41% savings ✅, short prompts pass-through ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)