### PR TITLE
feat(hooks): activity log + hook-stats subcommand + crash guard

### DIFF
--- a/rtk_sf/__main__.py
+++ b/rtk_sf/__main__.py
@@ -476,6 +476,52 @@ def cmd_ui(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_hook_stats(args: argparse.Namespace) -> int:
+    """Show recent hook activity from ~/.rtk-sf-hooks.log."""
+    from pathlib import Path as _Path
+    log_path = _Path.home() / ".rtk-sf-hooks.log"
+    if not log_path.exists():
+        _warn("No hook log yet — hooks have not fired since last install.")
+        _info("Tip: hooks only fire inside a Claude Code session.")
+        return 0
+
+    from rtk_sf.hooks._log import tail
+    n = getattr(args, "lines", 20)
+    records = tail(n)
+    if not records:
+        _warn("Log exists but is empty.")
+        return 0
+
+    import json as _json
+    # Summary counters
+    stats: dict[str, dict[str, int]] = {}
+    for r in records:
+        hook = r.get("hook", "?")
+        status = r.get("status", "?")
+        stats.setdefault(hook, {}).setdefault(status, 0)
+        stats[hook][status] += 1
+
+    _bold("\n━━━  rtk-sf hook activity (last %d entries)  ━━━" % len(records))
+    print()
+    for hook, counts in stats.items():
+        label = {"compact": "NLP compact_prompt", "ocr": "OCR intercept"}.get(hook, hook)
+        print(f"  {label}:")
+        for status, count in counts.items():
+            print(f"    {status:30s}  ×{count}")
+    print()
+    _bold("Recent entries:")
+    for r in records[-10:]:
+        ts = r.get("ts", "")[:19].replace("T", " ")
+        hook = r.get("hook", "?")
+        status = r.get("status", "?")
+        extra = {k: v for k, v in r.items() if k not in ("ts", "hook", "status")}
+        extra_str = ("  " + _json.dumps(extra, ensure_ascii=False)) if extra else ""
+        print(f"  {ts}  [{hook:7s}]  {status}{extra_str}")
+    print()
+    _info(f"Full log: {log_path}")
+    return 0
+
+
 # ---------------------------------------------------------------------------
 # Argument parser
 # ---------------------------------------------------------------------------
@@ -576,6 +622,20 @@ Built by furuCRM Inc. — https://www.furucrm.com
         help="Output HTML path (default: dist/architecture_map.html)",
     )
     p_ui.set_defaults(func=cmd_ui)
+
+    # hook-stats
+    p_stats = subparsers.add_parser(
+        "hook-stats",
+        help="Show recent OCR / NLP hook activity from ~/.rtk-sf-hooks.log",
+    )
+    p_stats.add_argument(
+        "-n", "--lines",
+        type=int,
+        default=20,
+        metavar="N",
+        help="Number of log entries to display (default: 20)",
+    )
+    p_stats.set_defaults(func=cmd_hook_stats)
 
     return parser
 

--- a/rtk_sf/hooks/_log.py
+++ b/rtk_sf/hooks/_log.py
@@ -1,0 +1,42 @@
+"""Shared append-only log for rtk-sf hooks.
+
+Log file: ~/.rtk-sf-hooks.log
+Format (JSONL):  {"ts": "ISO8601", "hook": "compact|ocr", "status": "...", ...}
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+
+_LOG_PATH = Path.home() / ".rtk-sf-hooks.log"
+_MAX_LINES = 500
+
+
+def append(hook: str, status: str, **kwargs: object) -> None:
+    record = {"ts": datetime.now(timezone.utc).isoformat(), "hook": hook, "status": status, **kwargs}
+    try:
+        with _LOG_PATH.open("a", encoding="utf-8") as f:
+            f.write(json.dumps(record, ensure_ascii=False) + "\n")
+        _trim()
+    except Exception:
+        pass
+
+
+def _trim() -> None:
+    try:
+        lines = _LOG_PATH.read_text(encoding="utf-8").splitlines(keepends=True)
+        if len(lines) > _MAX_LINES:
+            _LOG_PATH.write_text("".join(lines[-_MAX_LINES:]), encoding="utf-8")
+    except Exception:
+        pass
+
+
+def tail(n: int = 20) -> list[dict]:
+    try:
+        lines = _LOG_PATH.read_text(encoding="utf-8").splitlines()
+        return [json.loads(l) for l in lines[-n:] if l.strip()]
+    except Exception:
+        return []

--- a/rtk_sf/hooks/compact_prompt.py
+++ b/rtk_sf/hooks/compact_prompt.py
@@ -11,7 +11,7 @@ Claude Code hook protocol:
 Only fires when:
   - prompt length > 300 chars AND
   - contains Japanese characters OR length > 800 chars (long English prompt)
-  - compaction achieves > 50 char reduction
+  - compaction achieves > 5% reduction
 """
 
 from __future__ import annotations
@@ -39,16 +39,26 @@ def main() -> None:
     threshold = MIN_CHARS_JA if has_ja else MIN_CHARS_EN
 
     if len(prompt) < threshold:
+        from rtk_sf.hooks._log import append
+        append("compact", "skip:too_short", chars=len(prompt), threshold=threshold)
         sys.exit(0)
 
     try:
         from rtk_sf.nlp_compactor import compact_prompt
+        from rtk_sf.hooks._log import append
         compacted, orig_chars, new_chars = compact_prompt(prompt)
         savings_pct = (orig_chars - new_chars) / orig_chars * 100 if orig_chars else 0
         if savings_pct < MIN_SAVINGS_PCT:
+            append("compact", "skip:no_savings", orig=orig_chars, new=new_chars, pct=round(savings_pct, 1))
             sys.exit(0)
+        append("compact", "ok", orig=orig_chars, new=new_chars, pct=round(savings_pct, 1))
         sys.stdout.write(json.dumps({"prompt": compacted}))
-    except Exception:
+    except Exception as exc:
+        try:
+            from rtk_sf.hooks._log import append
+            append("compact", "error", err=str(exc))
+        except Exception:
+            pass
         sys.exit(0)
 
 

--- a/rtk_sf/hooks/compact_prompt.py
+++ b/rtk_sf/hooks/compact_prompt.py
@@ -39,8 +39,11 @@ def main() -> None:
     threshold = MIN_CHARS_JA if has_ja else MIN_CHARS_EN
 
     if len(prompt) < threshold:
-        from rtk_sf.hooks._log import append
-        append("compact", "skip:too_short", chars=len(prompt), threshold=threshold)
+        try:
+            from rtk_sf.hooks._log import append
+            append("compact", "skip:too_short", chars=len(prompt), threshold=threshold)
+        except Exception:
+            pass
         sys.exit(0)
 
     try:

--- a/rtk_sf/hooks/ocr_intercept.py
+++ b/rtk_sf/hooks/ocr_intercept.py
@@ -31,11 +31,16 @@ def main() -> None:
     if not file_path or Path(file_path).suffix.lower() not in IMAGE_EXTS:
         sys.exit(0)
 
-    from rtk_sf.hooks._log import append
+    try:
+        from rtk_sf.hooks._log import append as _log
+    except Exception:
+        _log = None  # type: ignore[assignment]
+
     try:
         from rtk_sf.vision_ocr import extract_image_text
         text = extract_image_text(str(file_path))
-        append("ocr", "ok", path=file_path, chars=len(text))
+        if _log:
+            _log("ocr", "ok", path=file_path, chars=len(text))
         sys.stdout.write(
             f"[rtk-sf OCR] Intercepted Read on image — ran local OCR instead "
             f"(saves ~1,500 vision tokens).\n\n"
@@ -44,7 +49,8 @@ def main() -> None:
         )
         sys.exit(2)
     except Exception as exc:
-        append("ocr", "error", path=file_path, err=str(exc))
+        if _log:
+            _log("ocr", "error", path=file_path, err=str(exc))
         sys.stdout.write(f"[rtk-sf OCR] OCR failed ({exc}), falling back to native Read.\n")
         sys.exit(0)
 

--- a/rtk_sf/hooks/ocr_intercept.py
+++ b/rtk_sf/hooks/ocr_intercept.py
@@ -6,6 +6,10 @@ Claude Code hook protocol:
   stdin : JSON {"tool_name": "Read", "tool_input": {"file_path": "..."}, ...}
   exit 0: allow the Read to proceed normally
   exit 2: block — stdout text is shown to Claude as the result instead
+
+NOTE: inline pasted images bypass this hook entirely because Claude uses native
+vision without calling Read.  The CLAUDE.md guidance instructs Claude to ask for
+a file path in that case.
 """
 
 from __future__ import annotations
@@ -27,9 +31,11 @@ def main() -> None:
     if not file_path or Path(file_path).suffix.lower() not in IMAGE_EXTS:
         sys.exit(0)
 
+    from rtk_sf.hooks._log import append
     try:
         from rtk_sf.vision_ocr import extract_image_text
         text = extract_image_text(str(file_path))
+        append("ocr", "ok", path=file_path, chars=len(text))
         sys.stdout.write(
             f"[rtk-sf OCR] Intercepted Read on image — ran local OCR instead "
             f"(saves ~1,500 vision tokens).\n\n"
@@ -38,6 +44,7 @@ def main() -> None:
         )
         sys.exit(2)
     except Exception as exc:
+        append("ocr", "error", path=file_path, err=str(exc))
         sys.stdout.write(f"[rtk-sf OCR] OCR failed ({exc}), falling back to native Read.\n")
         sys.exit(0)
 


### PR DESCRIPTION
## Summary

- Adds `~/.rtk-sf-hooks.log` (JSONL, 500-line rolling) — both `compact_prompt` and `ocr_intercept` append a record on every invocation with status and metadata (chars, % savings, file path, error)
- New subcommand `python3 -m rtk_sf hook-stats [-n N]` — shows summary counters + last N entries so you can verify hooks are actually firing
- Guards all `_log` imports in try/except so a broken install never crashes a hook (hooks always exit 0 gracefully on any error)

## Verified

- `compact: skip:too_short` — EN 5 chars / JA 5 chars (threshold 300 / 50) ✅
- `compact: skip:no_savings` — 310 repetitive chars, 0.3% saving below 5% threshold ✅
- `compact: ok` — JA 161→152 chars, 5.6% saving, JSON output, exit 0 ✅
- `ocr`: non-image path → exit 0, no log entry ✅
- `ocr`: image path → exit 2, logged ✅
- `hook-stats -n` — correct summary counts + recent entries ✅
- `install` idempotent after changes ✅

## Usage

```bash
python3 -m rtk_sf hook-stats
python3 -m rtk_sf hook-stats -n 50
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)