### PR TITLE
fix(deps): relax pyyaml>=6.0.3 to >=6.0.2 — fixes Windows Japanese username install failure

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ classifiers = [
 requires-python = ">=3.9"
 dependencies = [
     "watchdog>=6.0.0",
-    "pyyaml>=6.0.3",
+    "pyyaml>=6.0.2",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## 原因

`pyyaml>=6.0.3` が `paddlex`（paddleocr 3.x の依存）の `PyYAML==6.0.2` と衝突し、以下の連鎖が発生していた：

1. pip が paddlex を 3.0.1 までバックトラック → `numpy==1.26.4` に固定
2. numpy 1.26.4 に Python 3.14 用 wheel が無い → sdist ビルド開始
3. meson-python 0.15.0 がエンコーディング指定なしで native-file を書く（cp932）
4. Meson が UTF-8 で読む → 日本語ユーザー名パスで `UnicodeDecodeError`

## 修正

`pyyaml>=6.0.3` → `>=6.0.2` に緩めるだけ。

これにより paddleocr 3.7.x が `numpy 2.3.5`（Python 3.14 cp314 wheel あり）で解決し、sdist ビルド自体が発生しなくなる。

## 変更

`pyproject.toml` の1行のみ：
```
- "pyyaml>=6.0.2",   # was >=6.0.3
```

Fixes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)