### PR TITLE
fix(windows): use shell=True on Windows so sf.cmd resolves correctly

### DIFF
--- a/rtk_sf/data_tools.py
+++ b/rtk_sf/data_tools.py
@@ -22,12 +22,16 @@ import json
 import logging
 import re
 import subprocess
+import sys
 from pathlib import Path
 from typing import Any
 
 import yaml
 
 logger = logging.getLogger(__name__)
+
+# On Windows, sf is installed as sf.cmd; shell=True is required to resolve it.
+_SHELL = sys.platform == "win32"
 
 _SAMPLE_SIZE_DEFAULT = 3
 _LIMIT_RE = re.compile(r"\bLIMIT\s+(\d+)\b", re.IGNORECASE)
@@ -212,7 +216,7 @@ def run_soql(
     logger.info("soql: %s", capped_query)
 
     try:
-        proc = subprocess.run(cmd, capture_output=True, text=True, timeout=60)
+        proc = subprocess.run(cmd, capture_output=True, text=True, timeout=60, shell=_SHELL)
     except FileNotFoundError:
         return "❌ sf CLI not found. Install: https://developer.salesforce.com/tools/salesforcecli"
     except subprocess.TimeoutExpired:

--- a/rtk_sf/sf_runner.py
+++ b/rtk_sf/sf_runner.py
@@ -24,10 +24,15 @@ from __future__ import annotations
 import json
 import logging
 import subprocess
+import sys
 import time
 from typing import Any
 
 logger = logging.getLogger(__name__)
+
+# On Windows, sf is installed as sf.cmd (a batch file).
+# subprocess without shell=True cannot execute .cmd files directly.
+_SHELL = sys.platform == "win32"
 
 # ---------------------------------------------------------------------------
 # Action → sf CLI mapping
@@ -175,6 +180,7 @@ def run_sf_command(action: str, args: dict[str, Any] | None = None) -> str:
             capture_output=True,
             text=True,
             timeout=600,
+            shell=_SHELL,
         )
     except FileNotFoundError:
         return "❌ sf CLI not found. Install: https://developer.salesforce.com/tools/salesforcecli"


### PR DESCRIPTION
## 原因

Windows の Salesforce CLI は `sf.cmd`（バッチファイル）としてインストールされる。

`subprocess.run(["sf", ...], shell=False)`（デフォルト）は `.cmd` ファイルを直接実行できないため、`sf` が PATH に存在していても `FileNotFoundError` になる。

**影響箇所：**
- `sf_runner.py` → `sf_command` MCP ツール（deploy / retrieve / run_test / describe）
- `data_tools.py` → `soql_query` MCP ツール

## 修正

`sys.platform == "win32"` のときのみ `shell=True` を渡す。  
macOS / Linux は従来通り `shell=False` のまま。

```python
_SHELL = sys.platform == "win32"

subprocess.run(cmd, ..., shell=_SHELL)
```

`shell=True` on Windows は cmd.exe が `.cmd` 拡張子を自動解決するため、`sf.cmd` が正しく起動される。引数はリスト形式のまま渡しているため、`subprocess.list2cmdline` で安全にクォート処理される。

## 変更ファイル

- `rtk_sf/sf_runner.py` — `_SHELL` 定数追加 + `subprocess.run` に `shell=_SHELL`
- `rtk_sf/data_tools.py` — 同上

🤖 Generated with [Claude Code](https://claude.com/claude-code)