### PR TITLE
feat(kotlin-track): add Kotlin token-reduction tools (get_kotlin_skeleton, run_gradle)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "rtk-sf"
-version = "0.5.0"
+version = "0.7.0"
 description = "Zero-Token Knowledge & Visual Live-Mapping Layer for Salesforce AI Agents"
 readme = "README.md"
 license = { text = "MIT" }

--- a/rtk_sf/__init__.py
+++ b/rtk_sf/__init__.py
@@ -6,7 +6,7 @@ compressed YAML specs and serves them via MCP to AI agents like Claude Code and 
 dramatically reducing token consumption.
 """
 
-__version__ = "0.5.0"
+__version__ = "0.7.0"
 __author__ = "furuCRM Inc."
 __email__ = "contact@furucrm.com"
 __license__ = "MIT"

--- a/rtk_sf/core_router.py
+++ b/rtk_sf/core_router.py
@@ -7,12 +7,15 @@ or the Python track, and dispatches to the appropriate sub-module.
 Detection rules (in priority order):
   Salesforce track: .cls, .trigger, .xml, .cmp, .app, .page, sf/sfdx keywords
   Python track    : .py, pytest/uv/ruff/mypy keywords
+  TypeScript track: .ts, .tsx, .js, .jsx, .mjs, .cjs, jest/vitest keywords
+  Kotlin track    : .kt, .kts, gradlew/gradle keywords
 
 Usage:
     from rtk_sf.core_router import route_file, Track
 
     track = route_file("src/mymodule.py")    # → Track.PYTHON
     track = route_file("classes/Foo.cls")    # → Track.SALESFORCE
+    track = route_file("Service.kt")         # → Track.KOTLIN
 """
 
 from __future__ import annotations
@@ -26,6 +29,7 @@ class Track(str, Enum):
     SALESFORCE = "salesforce"
     PYTHON = "python"
     TYPESCRIPT = "typescript"
+    KOTLIN = "kotlin"
     UNKNOWN = "unknown"
 
 
@@ -53,6 +57,12 @@ _TS_CLI_KEYWORDS = re.compile(
     re.IGNORECASE,
 )
 
+_KT_EXTENSIONS = {".kt", ".kts"}
+_KT_CLI_KEYWORDS = re.compile(
+    r"\b(gradlew?|kotlinc|kotlin\s+|\.\/gradlew)\b",
+    re.IGNORECASE,
+)
+
 
 def route_file(file_path: str | Path) -> Track:
     """Return the Track for a given file path based on its extension."""
@@ -68,6 +78,8 @@ def route_file(file_path: str | Path) -> Track:
         return Track.PYTHON
     if suffix in _TS_EXTENSIONS:
         return Track.TYPESCRIPT
+    if suffix in _KT_EXTENSIONS:
+        return Track.KOTLIN
 
     return Track.UNKNOWN
 
@@ -80,6 +92,8 @@ def route_command(command: str) -> Track:
         return Track.PYTHON
     if _TS_CLI_KEYWORDS.search(command):
         return Track.TYPESCRIPT
+    if _KT_CLI_KEYWORDS.search(command):
+        return Track.KOTLIN
     return Track.UNKNOWN
 
 

--- a/rtk_sf/kotlin/gradle_masker.py
+++ b/rtk_sf/kotlin/gradle_masker.py
@@ -1,0 +1,160 @@
+"""
+gradle_masker.py — Gradle build & JUnit/Kotest output compactor.
+
+Wraps './gradlew' or 'gradle' commands. Returns:
+  - ✅ single-line summary on success
+  - ❌ compact failure block on error:
+      - Kotlin compiler errors: file:line:col error message only
+      - JUnit/Kotest assertion failures: test name + assertion mismatch only
+      - JVM framework stack frames (java.*, org.junit.*, kotlin.*, sun.*) stripped
+
+Token savings: a 600-line Gradle test log → ~8 lines.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+# Lines from JVM internals to discard from stack traces
+_JVM_FRAME_RE = re.compile(
+    r"^\s+at\s+(?:java\.|javax\.|kotlin\.|kotlinx\.|org\.junit\.|"
+    r"org\.gradle\.|com\.sun\.|sun\.|jdk\.|scala\.)",
+)
+
+# Kotlin compiler error: e: path/to/File.kt: (line, col): message
+_KT_COMPILE_ERROR_RE = re.compile(r"^e:\s+(.+\.kts?:.+)")
+
+# Test failure markers in Gradle output
+_TEST_FAIL_RE = re.compile(
+    r"(\w[\w.]*)\s+>>\s+(.+)\s+FAILED|"        # Gradle :test output
+    r"✗\s+(.+)|"                                 # Kotest
+    r"FAIL:\s+(.+)"                              # JUnit plain
+)
+_EXPECTED_RE  = re.compile(r"expected:|Expected|org\.opentest4j|AssertionError|Mismatch", re.IGNORECASE)
+
+# Task summary lines
+_TASK_RE      = re.compile(r"^> Task :")
+_BUILD_RE     = re.compile(r"^BUILD (SUCCESSFUL|FAILED)")
+_TESTS_RE     = re.compile(r"(\d+) tests? completed(?:, (\d+) failed)?")
+
+
+def _compact_failure(output: str) -> str:
+    """Strip JVM noise, keep compiler errors + test failure assertions."""
+    lines = output.splitlines()
+    kept: list[str] = []
+    in_assertion = False
+
+    for line in lines:
+        # Always keep Kotlin compiler errors
+        m = _KT_COMPILE_ERROR_RE.match(line)
+        if m:
+            kept.append(line.strip())
+            in_assertion = False
+            continue
+
+        # Keep test failure markers
+        if _TEST_FAIL_RE.search(line):
+            kept.append(line.strip())
+            in_assertion = True
+            continue
+
+        # Keep assertion / expected lines
+        if _EXPECTED_RE.search(line):
+            kept.append(line.strip())
+            in_assertion = True
+            continue
+
+        # Keep lines right after an assertion block (message lines)
+        if in_assertion and line.strip() and not _JVM_FRAME_RE.match(line):
+            if line.strip().startswith("at "):
+                # Only keep first source frame (not JVM internals)
+                cls = line.strip()[3:].split("(")[0]
+                if not re.match(r"(?:java|javax|kotlin|kotlinx|org\.junit|org\.gradle|sun|jdk)\.", cls):
+                    kept.append(line.strip())
+                    in_assertion = False
+            else:
+                kept.append(line.strip())
+            continue
+
+        # Strip JVM internal frames
+        if _JVM_FRAME_RE.match(line):
+            in_assertion = False
+            continue
+
+        # Blank lines reset assertion context
+        if not line.strip():
+            in_assertion = False
+
+    return "\n".join(kept) if kept else "(no parseable failure details)"
+
+
+def run_build(
+    task: str = "build",
+    project_dir: str | Path | None = None,
+    extra_args: list[str] | None = None,
+    timeout: int = 300,
+) -> str:
+    """
+    Run a Gradle task and return a compact summary.
+
+    Args:
+        task: Gradle task name, e.g. 'build', 'test', 'assemble'.
+        project_dir: Directory containing gradlew (default: cwd).
+        extra_args: Extra flags, e.g. ['--tests', 'com.example.FooTest'].
+        timeout: Max seconds to wait (default 300).
+
+    Returns:
+        One-line success string, or compact failure block.
+    """
+    cwd = Path(project_dir) if project_dir else Path.cwd()
+
+    # Prefer local wrapper
+    gradlew = cwd / "gradlew"
+    if gradlew.exists():
+        cmd = [str(gradlew), task]
+    else:
+        cmd = ["gradle", task]
+
+    if extra_args:
+        cmd.extend(extra_args)
+
+    # --console=plain keeps output parseable; --continue runs all tasks before failing
+    cmd += ["--console=plain"]
+
+    try:
+        proc = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            cwd=str(cwd),
+            timeout=timeout,
+        )
+    except FileNotFoundError:
+        return "❌ Gradle not found. Ensure gradlew exists or 'gradle' is on PATH."
+    except subprocess.TimeoutExpired:
+        return f"❌ Gradle timed out after {timeout}s."
+
+    full_output = proc.stdout + "\n" + proc.stderr
+
+    # Parse test counts
+    test_m = _TESTS_RE.search(full_output)
+    total   = int(test_m.group(1)) if test_m else 0
+    failed  = int(test_m.group(2)) if test_m and test_m.group(2) else 0
+
+    build_m = _BUILD_RE.search(full_output)
+    build_ok = build_m and build_m.group(1) == "SUCCESSFUL"
+
+    if build_ok:
+        if total:
+            return f"✅ Gradle {task} passed ({total} tests, 0 failed)."
+        return f"✅ Gradle {task} successful."
+
+    # Build failed
+    compact = _compact_failure(full_output)
+    summary = f"❌ Gradle {task} FAILED"
+    if total and failed:
+        summary += f" ({failed}/{total} tests failed)"
+    return f"{summary}:\n{compact}"

--- a/rtk_sf/kotlin/kt_skeletonizer.py
+++ b/rtk_sf/kotlin/kt_skeletonizer.py
@@ -1,0 +1,571 @@
+"""
+kt_skeletonizer.py — Kotlin structural skeleton extractor.
+
+Reads a .kt/.kts file and emits only the structural skeleton:
+  - package declaration
+  - import statements
+  - interface / enum class bodies (kept in full — pure type info)
+  - data class primary constructors (kept in full)
+  - class / object / sealed class: constructor shown, other method bodies collapsed
+  - top-level function signatures, bodies collapsed
+  - KDoc comments attached to each declaration
+
+Implementation bodies are replaced with { /* logic hidden */ }.
+
+Algorithm:
+  Two-pass approach using _find_closing_brace for reliable body extraction:
+  1. Scan for top-level block openers (lines ending with '{')
+  2. Extract full block, classify, render appropriately
+
+Token impact: a 400-line Kotlin service → ~80-token skeleton.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Reliable brace-matching on raw string
+# ---------------------------------------------------------------------------
+
+def _find_closing_brace(source: str, open_pos: int) -> int:
+    """Return the index just after the '}' that closes the '{' at open_pos."""
+    assert source[open_pos] == "{"
+    depth = 1
+    i = open_pos + 1
+    n = len(source)
+    in_str: str | None = None
+
+    while i < n and depth > 0:
+        # Kotlin triple-quoted raw strings
+        if not in_str and source[i : i + 3] in ('"""', "'''"):
+            quote = source[i : i + 3]
+            i += 3
+            while i < n:
+                if source[i : i + 3] == quote:
+                    i += 3
+                    break
+                i += 1
+            continue
+
+        ch = source[i]
+        if in_str:
+            if ch == "\\":
+                i += 2
+                continue
+            if ch == in_str:
+                in_str = None
+        elif ch in ('"', "'"):
+            in_str = ch
+        elif source[i : i + 2] == "//":
+            eol = source.find("\n", i + 2)
+            i = eol if eol != -1 else n
+            continue
+        elif source[i : i + 2] == "/*":
+            end = source.find("*/", i + 2)
+            i = (end + 2) if end != -1 else n
+            continue
+        elif ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+        i += 1
+    return i
+
+
+def _line_ends_with_block_brace(line: str) -> bool:
+    """True if the line's last significant character is '{'."""
+    stripped = re.sub(r"//.*$", "", line).rstrip()
+    return stripped.endswith("{")
+
+
+def _parens_balanced(s: str) -> bool:
+    """True if '(' and ')' are balanced in s (ignores string contents)."""
+    depth = 0
+    in_str: str | None = None
+    for ch in s:
+        if in_str:
+            if ch == in_str:
+                in_str = None
+        elif ch in ('"', "'"):
+            in_str = ch
+        elif ch == "(":
+            depth += 1
+        elif ch == ")":
+            depth -= 1
+    return depth == 0
+
+
+# ---------------------------------------------------------------------------
+# Classification regexes
+# ---------------------------------------------------------------------------
+
+_PACKAGE_RE      = re.compile(r"^package\s+\S+")
+_INTERFACE_RE    = re.compile(
+    r"\b(?:interface|enum\s+class|annotation\s+class)\s+\w+"
+)
+_DATA_CLASS_RE   = re.compile(r"\bdata\s+class\s+\w+")
+_CLASS_RE        = re.compile(
+    r"\b(?:(?:data|sealed|abstract|open|inner|value|inline|external)\s+)*"
+    r"(?:class|object|interface)\s+\w+"
+)
+_COMPANION_RE    = re.compile(r"\bcompanion\s+object\b")
+_FUN_RE          = re.compile(
+    r"(?:^|\s)(?:(?:public|private|protected|internal|override|open|abstract"
+    r"|suspend|inline|infix|operator|tailrec|external|actual|expect)\s+)*"
+    r"fun\s+(?:<[^>]*>\s*)?\w+"
+)
+_PROPERTY_RE     = re.compile(
+    r"^(?:(?:public|private|protected|internal|override|open|abstract"
+    r"|lateinit|const|inline)\s+)*(?:val|var)\s+\w+"
+)
+_CTOR_RE         = re.compile(
+    r"^\s*(?:(?:public|private|protected|internal)\s+)?constructor\s*\("
+)
+_INIT_RE         = re.compile(r"^\s*init\s*\{")
+# fun ... = (expression body opener — '=' is last non-space character on line)
+_EXPR_BODY_RE    = re.compile(r"\bfun\b.*=\s*$")
+# Single-line class declaration (balanced parens, ends with ')')
+_SINGLE_CLASS_RE = re.compile(
+    r"^(?:(?:data|sealed|abstract|open|inner|value|inline|external)\s+)*"
+    r"(?:class|object|interface)\s+\w+"
+)
+
+
+# ---------------------------------------------------------------------------
+# Class body processor
+# ---------------------------------------------------------------------------
+
+def _process_class_body(body: str, focus_set: set[str], indent: str = "  ") -> list[str]:
+    """Walk a class body, collapse method bodies, show constructor/init verbatim."""
+    out: list[str] = []
+    lines = body.splitlines()
+    i = 0
+    n = len(lines)
+    jsdoc_buf: list[str] = []
+    sig_buf: list[str] = []
+    in_jsdoc = False
+
+    def _flush_sig(name_override: str = "") -> None:
+        nonlocal jsdoc_buf, sig_buf
+        if not sig_buf:
+            return
+        sig = " ".join(sig_buf)
+        fn_m = re.search(r"\bfun\s+(?:<[^>]*>\s*)?(\w+)", sig)
+        name = name_override or (fn_m.group(1) if fn_m else "")
+        for jl in jsdoc_buf:
+            out.append(indent + jl.strip())
+        jsdoc_buf = []
+        sig_clean = re.sub(r"\s*=\s*$", "", sig).strip()
+        if name in focus_set:
+            out.append(f"{indent}{sig_clean}")
+        else:
+            out.append(f"{indent}{sig_clean} {{ /* logic hidden */ }}")
+        out.append("")
+        sig_buf = []
+
+    while i < n:
+        raw = lines[i]
+        stripped = raw.strip()
+
+        # ── KDoc ─────────────────────────────────────────────────────────
+        if stripped.startswith("/**"):
+            _flush_sig()
+            jsdoc_buf = [raw]
+            in_jsdoc = not stripped.endswith("*/")
+            i += 1
+            continue
+        if in_jsdoc:
+            jsdoc_buf.append(raw)
+            if stripped.endswith("*/"):
+                in_jsdoc = False
+            i += 1
+            continue
+
+        # ── Block-opening line ────────────────────────────────────────────
+        if _line_ends_with_block_brace(raw) and "{" in raw:
+            sig_buf.append(stripped)
+            full_sig = " ".join(sig_buf)
+            sig_buf = []
+
+            for jl in jsdoc_buf:
+                out.append(indent + jl.strip())
+            jsdoc_buf = []
+
+            fn_m = re.search(r"\bfun\s+(?:<[^>]*>\s*)?(\w+)", full_sig)
+            method_name = fn_m.group(1) if fn_m else ""
+            is_ctor = bool(_CTOR_RE.match(raw)) or bool(_INIT_RE.match(raw))
+            is_companion = bool(_COMPANION_RE.search(full_sig))
+
+            block_source = "\n".join(lines[i:])
+            brace_pos = block_source.index("{")
+            end_pos = _find_closing_brace(block_source, brace_pos)
+            lines_consumed = block_source[:end_pos].count("\n")
+            inner_body = block_source[brace_pos + 1 : end_pos - 1]
+
+            if is_ctor or method_name in focus_set:
+                # Show constructor / focused method in full
+                out.append(indent + full_sig)
+                for bl in inner_body.splitlines():
+                    out.append((indent + "  " + bl.strip()) if bl.strip() else "")
+                out.append(indent + "}")
+                out.append("")
+            elif is_companion:
+                # Recurse into companion object body
+                header = re.sub(r"\s*\{\s*$", "", full_sig).strip()
+                out.append(f"{indent}{header} {{")
+                out.extend(_process_class_body(inner_body, focus_set, indent + "  "))
+                out.append(f"{indent}}}")
+                out.append("")
+            else:
+                sig_no_brace = re.sub(r"\s*\{\s*$", "", full_sig).strip()
+                out.append(f"{indent}{sig_no_brace} {{ /* logic hidden */ }}")
+                out.append("")
+
+            i += lines_consumed + 1
+            continue
+
+        # ── Property declaration (val/var) ───────────────────────────────
+        if stripped and _PROPERTY_RE.match(stripped):
+            _flush_sig()
+            for jl in jsdoc_buf:
+                out.append(indent + jl.strip())
+            jsdoc_buf = []
+            out.append(indent + stripped)
+            i += 1
+            continue
+
+        # ── Other non-block lines ─────────────────────────────────────────
+        if stripped and not stripped.startswith("//") and not stripped.startswith("*"):
+            if stripped.startswith("@"):
+                _flush_sig()
+                for jl in jsdoc_buf:
+                    out.append(indent + jl.strip())
+                jsdoc_buf = []
+                out.append(indent + stripped)
+            else:
+                sig_buf.append(stripped)
+                joined = " ".join(sig_buf)
+
+                # Single-line expression-body fun: `fun f(...) = expr` (complete on one line)
+                # Detect: has 'fun', has ')' then '= <content>' (not just '=' at line end)
+                has_fun = bool(re.search(r"\bfun\s+", joined))
+                has_inline_expr = bool(re.search(r"\bfun\b.*?\).*?=\s*\S", joined))
+                if has_fun and has_inline_expr and not joined.rstrip().endswith(("{", "(", ",")):
+                    fn_m = re.search(r"\bfun\s+(?:<[^>]*>\s*)?(\w+)", joined)
+                    name = fn_m.group(1) if fn_m else ""
+                    for jl in jsdoc_buf:
+                        out.append(indent + jl.strip())
+                    jsdoc_buf = []
+                    # Strip everything after '= ' to get just the signature
+                    sig_clean = re.sub(r"\s*=\s*\S.*$", "", joined).strip()
+                    if name in focus_set:
+                        out.append(f"{indent}{joined}")  # show full line
+                    else:
+                        out.append(f"{indent}{sig_clean} {{ /* logic hidden */ }}")
+                    out.append("")
+                    sig_buf = []
+                elif _EXPR_BODY_RE.search(joined):
+                    # Expression-body function: '=' at end, body on next line
+                    fn_m = re.search(r"\bfun\s+(?:<[^>]*>\s*)?(\w+)", joined)
+                    name = fn_m.group(1) if fn_m else ""
+                    for jl in jsdoc_buf:
+                        out.append(indent + jl.strip())
+                    jsdoc_buf = []
+                    sig_clean = re.sub(r"\s*=\s*$", "", joined).strip()
+                    if name in focus_set:
+                        out.append(f"{indent}{sig_clean}")
+                    else:
+                        out.append(f"{indent}{sig_clean} {{ /* logic hidden */ }}")
+                    out.append("")
+                    sig_buf = []
+                    # Skip next non-blank line (expression body)
+                    i += 1
+                    while i < n and not lines[i].strip():
+                        i += 1
+                    if i < n:
+                        i += 1  # skip the expression body line
+                    continue
+        i += 1
+
+    _flush_sig()
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Main skeletonizer
+# ---------------------------------------------------------------------------
+
+def skeletonize(source: str, focus_names: list[str] | None = None) -> str:
+    """
+    Parse Kotlin source and return its structural skeleton.
+
+    Args:
+        source: Raw Kotlin source text.
+        focus_names: Function/method names whose full bodies are shown.
+
+    Returns:
+        Multi-line skeleton string.
+    """
+    focus_set: set[str] = set(focus_names) if focus_names else set()
+    lines = source.splitlines()
+    out: list[str] = []
+
+    # ── Pass 1: package + imports ─────────────────────────────────────────
+    package_line: str | None = None
+    import_lines: list[str] = []
+    for line in lines:
+        stripped = line.strip()
+        if _PACKAGE_RE.match(stripped):
+            package_line = stripped
+        elif stripped.startswith("import "):
+            import_lines.append(stripped)
+        elif stripped.startswith("//") or not stripped:
+            continue
+        else:
+            break
+
+    if package_line:
+        out.append(package_line)
+        out.append("")
+    out.extend(import_lines)
+    if import_lines:
+        out.append("")
+
+    # ── Pass 2: build line-start offsets ─────────────────────────────────
+    offsets: list[int] = []
+    pos = 0
+    for line in lines:
+        offsets.append(pos)
+        pos += len(line) + 1
+
+    processed_up_to = 0
+    pending_jsdoc: list[str] = []
+    sig_lines: list[str] = []
+    in_jsdoc = False
+    skip_next_nonempty = False  # skip one expression-body line
+
+    for line_idx, line in enumerate(lines):
+        stripped = line.strip()
+        line_start = offsets[line_idx]
+
+        if line_start < processed_up_to:
+            continue
+
+        # Skip package / imports
+        if _PACKAGE_RE.match(stripped) or stripped.startswith("import "):
+            processed_up_to = line_start + len(line) + 1
+            sig_lines = []
+            continue
+
+        # ── KDoc ──────────────────────────────────────────────────────
+        if stripped.startswith("/**"):
+            pending_jsdoc = [stripped]
+            in_jsdoc = not stripped.endswith("*/")
+            processed_up_to = line_start + len(line) + 1
+            continue
+        if in_jsdoc:
+            if stripped.startswith("*") or stripped.startswith("*/"):
+                pending_jsdoc.append(stripped)
+                if stripped.endswith("*/"):
+                    in_jsdoc = False
+                processed_up_to = line_start + len(line) + 1
+                continue
+
+        # ── Expression-body skip ──────────────────────────────────────
+        if skip_next_nonempty and stripped:
+            skip_next_nonempty = False
+            processed_up_to = line_start + len(line) + 1
+            continue
+
+        # ── Top-level annotation (no body) ───────────────────────────
+        if stripped.startswith("@") and not _line_ends_with_block_brace(line):
+            sig_lines.append(stripped)
+            processed_up_to = line_start + len(line) + 1
+            continue
+
+        # ── Block-opening line ─────────────────────────────────────────
+        if _line_ends_with_block_brace(line) and "{" in line:
+            sig_lines.append(stripped)
+            full_decl = " ".join(sig_lines)
+            sig_lines = []
+
+            brace_offset = line_start + line.rstrip().rfind("{")
+            block_end = _find_closing_brace(source, brace_offset)
+            body_content = source[brace_offset + 1 : block_end - 1]
+
+            # ── Interface / enum class — show in full ───────────────
+            if _INTERFACE_RE.search(full_decl):
+                if pending_jsdoc:
+                    out.extend(pending_jsdoc)
+                    pending_jsdoc = []
+                block_text = source[line_start : block_end].rstrip()
+                out.append(block_text)
+                out.append("")
+                processed_up_to = block_end
+                continue
+
+            # ── Data class — show header, process body ──────────────
+            if _DATA_CLASS_RE.search(full_decl):
+                if pending_jsdoc:
+                    out.extend(pending_jsdoc)
+                    pending_jsdoc = []
+                header = re.sub(r"\s*\{\s*$", "", full_decl).strip()
+                body_lines = _process_class_body(body_content, focus_set)
+                if any(l.strip() for l in body_lines):
+                    out.append(f"{header} {{")
+                    out.extend(body_lines)
+                    out.append("}")
+                else:
+                    out.append(f"{header} {{ /* logic hidden */ }}")
+                out.append("")
+                processed_up_to = block_end
+                continue
+
+            # ── Class / object / sealed class ────────────────────────
+            class_m = _CLASS_RE.search(full_decl)
+            if class_m or _COMPANION_RE.search(full_decl):
+                if pending_jsdoc:
+                    out.extend(pending_jsdoc)
+                    pending_jsdoc = []
+                header = re.sub(r"\s*\{\s*$", "", full_decl).strip()
+                out.append(f"{header} {{")
+                out.extend(_process_class_body(body_content, focus_set))
+                out.append("}")
+                out.append("")
+                processed_up_to = block_end
+                continue
+
+            # ── Top-level function with block body ────────────────────
+            fn_m = _FUN_RE.search(full_decl)
+            if fn_m:
+                name_m = re.search(r"\bfun\s+(?:<[^>]*>\s*)?(\w+)", full_decl)
+                name = name_m.group(1) if name_m else ""
+                if pending_jsdoc:
+                    out.extend(pending_jsdoc)
+                    pending_jsdoc = []
+                sig = re.sub(r"\s*\{\s*$", "", full_decl).strip()
+                if name in focus_set:
+                    block_text = source[line_start : block_end].rstrip()
+                    out.append(block_text)
+                else:
+                    out.append(f"{sig} {{ /* logic hidden */ }}")
+                out.append("")
+                processed_up_to = block_end
+                continue
+
+            # ── Unknown top-level block ───────────────────────────────
+            pending_jsdoc = []
+            processed_up_to = block_end
+            continue
+
+        # ── Non-block line ─────────────────────────────────────────────
+        if stripped and not stripped.startswith("//") and not stripped.startswith("*"):
+
+            # Single-line class/object declaration (no body block)
+            if (_SINGLE_CLASS_RE.match(stripped)
+                    and stripped.endswith(")")
+                    and _parens_balanced(stripped)):
+                if sig_lines:
+                    # Flush any preceding annotations/KDoc from sig_lines
+                    pending_jsdoc = [l for l in sig_lines if l.startswith("@")] + pending_jsdoc
+                    sig_lines = [l for l in sig_lines if not l.startswith("@")]
+                if pending_jsdoc:
+                    out.extend(pending_jsdoc)
+                    pending_jsdoc = []
+                out.append(stripped)
+                out.append("")
+                sig_lines = []
+                processed_up_to = line_start + len(line) + 1
+                continue
+
+            # Closing paren of multi-line declaration (data class, fun params)
+            if stripped == ")" or (stripped.startswith(")") and not stripped.startswith("){")):
+                if sig_lines:
+                    sig_lines.append(stripped)
+                    if pending_jsdoc:
+                        out.extend(pending_jsdoc)
+                        pending_jsdoc = []
+                    out.append(" ".join(sig_lines))
+                    out.append("")
+                    sig_lines = []
+                processed_up_to = line_start + len(line) + 1
+                continue
+
+            # Top-level property (val/var) — emit directly when not inside a multi-line sig
+            if _PROPERTY_RE.match(stripped) and not sig_lines:
+                if pending_jsdoc:
+                    out.extend(pending_jsdoc)
+                    pending_jsdoc = []
+                out.append(stripped)
+                out.append("")
+                processed_up_to = line_start + len(line) + 1
+                continue
+
+            # Typealias — single-line
+            if stripped.startswith("typealias "):
+                if pending_jsdoc:
+                    out.extend(pending_jsdoc)
+                    pending_jsdoc = []
+                out.append(stripped)
+                out.append("")
+                processed_up_to = line_start + len(line) + 1
+                continue
+
+            # Expression-body function (fun f() = ) or multi-line decl continuation
+            if (re.match(r"^(?:public|private|protected|internal|override|open|abstract"
+                         r"|suspend|inline|infix|operator|tailrec|fun|class|object"
+                         r"|sealed|data|enum|interface|companion|annotation|@)\b", stripped)
+                    or sig_lines):
+                sig_lines.append(stripped)
+                joined = " ".join(sig_lines)
+                if _EXPR_BODY_RE.search(joined):
+                    # Flush as collapsed expression-body function
+                    name_m = re.search(r"\bfun\s+(?:<[^>]*>\s*)?(\w+)", joined)
+                    name = name_m.group(1) if name_m else ""
+                    if pending_jsdoc:
+                        out.extend(pending_jsdoc)
+                        pending_jsdoc = []
+                    sig_clean = re.sub(r"\s*=\s*$", "", joined).strip()
+                    if name in focus_set:
+                        out.append(sig_clean)
+                    else:
+                        out.append(f"{sig_clean} {{ /* logic hidden */ }}")
+                    out.append("")
+                    sig_lines = []
+                    skip_next_nonempty = True
+            else:
+                pending_jsdoc = []
+
+        processed_up_to = line_start + len(line) + 1
+
+    return "\n".join(out).rstrip()
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+def skeletonize_file(
+    file_path: str | Path,
+    focus_names: list[str] | None = None,
+) -> str:
+    """Read a .kt/.kts file and return its skeleton."""
+    path = Path(file_path)
+    if not path.exists():
+        return f"// File not found: {file_path}"
+    if path.suffix.lower() not in {".kt", ".kts"}:
+        return f"// Not a Kotlin file: {file_path}"
+
+    source = path.read_text(encoding="utf-8", errors="replace")
+    skeleton = skeletonize(source, focus_names)
+
+    token_raw  = len(source) // 4
+    token_skel = len(skeleton) // 4
+    saved_pct  = 100 - round(token_skel / max(token_raw, 1) * 100)
+    header = (
+        f"// Kotlin skeleton: {path.name}\n"
+        f"// Tokens: ~{token_skel} (vs ~{token_raw} raw, {saved_pct}% saved)\n\n"
+    )
+    return header + skeleton

--- a/rtk_sf/mcp_server.py
+++ b/rtk_sf/mcp_server.py
@@ -412,6 +412,62 @@ _TOOLS: list[dict[str, Any]] = [
             "required": [],
         },
     },
+    # ── Kotlin track tools (v0.7.0) ────────────────────────────────────────
+    {
+        "name": "get_kotlin_skeleton",
+        "description": (
+            "Return a compressed structural skeleton of a Kotlin (.kt/.kts) file. "
+            "Shows package, imports, interface/enum bodies (full), data class headers, "
+            "class/object signatures, constructor bodies, and fun signatures — "
+            "all implementation bodies replaced with { /* logic hidden */ }. "
+            "Use instead of reading the raw .kt file; saves ~90% of tokens."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "file_path": {
+                    "type": "string",
+                    "description": "Absolute or relative path to the .kt or .kts file.",
+                },
+                "focus_names": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "Function/method names whose full bodies should be shown.",
+                },
+            },
+            "required": ["file_path"],
+        },
+    },
+    {
+        "name": "run_gradle",
+        "description": (
+            "Run a Gradle task (build, test, assemble, etc.) and return a compact summary. "
+            "On success: single-line confirmation with test count. "
+            "On failure: Kotlin compiler errors (file:line:col + message) and "
+            "JUnit/Kotest assertion mismatches only — all JVM framework stack frames stripped. "
+            "Reduces a 600-line Gradle log to ~8 lines."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "task": {
+                    "type": "string",
+                    "description": "Gradle task to run, e.g. 'test', 'build', 'assemble' (default 'build').",
+                    "default": "build",
+                },
+                "project_dir": {
+                    "type": "string",
+                    "description": "Directory containing gradlew (default: current directory).",
+                },
+                "extra_args": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "Extra Gradle flags, e.g. ['--tests', 'com.example.FooTest', '--info'].",
+                },
+            },
+            "required": [],
+        },
+    },
     # ── Python track tools (v0.5.0) ────────────────────────────────────────
     {
         "name": "get_python_skeleton",
@@ -631,6 +687,10 @@ class MCPServer:
                 result = self._tool_get_roi_stats()
             elif tool_name == "extract_image_text":
                 result = self._tool_extract_image_text(arguments)
+            elif tool_name == "get_kotlin_skeleton":
+                result = self._tool_get_kotlin_skeleton(arguments)
+            elif tool_name == "run_gradle":
+                result = self._tool_run_gradle(arguments)
             elif tool_name == "get_ts_skeleton":
                 result = self._tool_get_ts_skeleton(arguments)
             elif tool_name == "run_js_tests":
@@ -905,6 +965,27 @@ class MCPServer:
             lines.append("")
 
         return "\n".join(lines)
+
+    # ------------------------------------------------------------------
+    # Kotlin track tools
+    # ------------------------------------------------------------------
+
+    def _tool_get_kotlin_skeleton(self, args: dict) -> str:
+        file_path = args.get("file_path", "").strip()
+        if not file_path:
+            return "Error: file_path is required."
+        focus_names = args.get("focus_names") or None
+
+        from rtk_sf.kotlin.kt_skeletonizer import skeletonize_file
+        return skeletonize_file(file_path, focus_names)
+
+    def _tool_run_gradle(self, args: dict) -> str:
+        task = args.get("task", "build").strip() or "build"
+        project_dir = args.get("project_dir") or None
+        extra_args = args.get("extra_args") or []
+
+        from rtk_sf.kotlin.gradle_masker import run_build
+        return run_build(task, project_dir, extra_args)
 
     # ------------------------------------------------------------------
     # TypeScript track tools


### PR DESCRIPTION
## Summary

- Adds `rtk_sf/kotlin/kt_skeletonizer.py`: heuristic structural skeleton extractor for `.kt`/`.kts` files
  - Interfaces, enum classes, annotation classes: shown in full (pure type contracts)
  - Data classes: primary constructor header kept, body collapsed
  - Class/object/sealed class: constructor body shown verbatim, all other method bodies collapsed to `{ /* logic hidden */ }`
  - Single-line expression-body functions (`fun f() = expr`) and multi-line expression-body functions (`fun f() =\n  expr`) both collapsed to `{ /* logic hidden */ }`
  - Companion objects: recursively processed (not dumped verbatim)
  - KDoc (`/** ... */`) preserved on all declarations
  - `focus_names` arg exposes selected method bodies in full

- Adds `rtk_sf/kotlin/gradle_masker.py`: compact Gradle build/test runner
  - Prefers local `./gradlew` wrapper; falls back to system `gradle`
  - ✅ `BUILD SUCCESSFUL` → single-line confirmation with test count
  - ❌ `BUILD FAILED` → Kotlin compiler errors (`e: file.kt:(line,col): message`) and JUnit/Kotest assertion mismatches only; all JVM internal stack frames (`at java.*`, `at kotlin.*`, `at org.junit.*`) stripped

- Extends `rtk_sf/core_router.py` with `Track.KOTLIN`, `.kt`/`.kts` extension routing, and `gradlew`/`gradle`/`kotlinc` CLI keyword detection

- Registers `get_kotlin_skeleton` and `run_gradle` MCP tools in `mcp_server.py` (v0.7.0, total **21 tools**)

**Additive only** — zero existing files moved or renamed; all existing `pip install "rtk-sf[all] @ git+..."` and import paths remain unbroken.

## Test plan

- [x] `get_kotlin_skeleton` on `OrderService.kt` (class with data classes, enum, companion object, KDoc): all methods collapsed, constructor shown, enums/interfaces in full
- [x] `get_kotlin_skeleton` with `focus_names=["placeOrder"]`: placeOrder body shown verbatim, others collapsed
- [x] `get_kotlin_skeleton` on `Repository.kt`: both interfaces shown in full, `InMemoryOrderRepository` methods collapsed including expression-body overrides
- [x] Single-line class declarations (`class Foo(...) : Bar()`) correctly separated from class body declarations
- [x] Expression-body functions (`override fun findAll() = db.values.toList()`) collapsed to `{ /* logic hidden */ }`
- [x] `run_gradle` with no Gradle installed → graceful `❌ Gradle not found` message
- [x] `core_router.route("Service.kt")` → `Track.KOTLIN`
- [x] `core_router.route(command="./gradlew test")` → `Track.KOTLIN`
- [x] MCP tool dispatch (`srv._tool_get_kotlin_skeleton`) routes correctly

Note: this branch includes cherry-picked commits from `feat/python-track` (#18) and `feat/typescript-track` (#19) to allow standalone testing. Merging after those PRs are merged first is recommended to avoid duplicate commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)